### PR TITLE
Add description of Flutter SDK to build linux apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,13 +164,10 @@ Please edit `cmake/user_config.cmake` file.
 | USE_VIRTUAL_KEYBOARD | Use Virtual Keyboard (only when you use `DESKTOP_SHELL`) |
 | USE_GLES3 | Use OpenGLES3 instead of OpenGLES2 |
 
-## 4. Running your Flutter app
+## 4. Running Flutter app
 
 ### Install Flutter SDK
-
-Please note that you must use the same version that you built Flutter embedder for. See also: [Building Flutter Engine embedder](./BUILDING-ENGINE-EMBEDDER.md)
-
-In tearms of Flutter SDK, see also: [Desktop support for Flutter](https://flutter.dev/desktop)
+See also: [Desktop support for Flutter](https://flutter.dev/desktop)
 
 ```Shell
 $ git clone https://github.com/flutter/flutter
@@ -180,7 +177,10 @@ $ flutter config --enable-linux-desktop
 $ flutter doctor
 ```
 
-### Build your Flutter app
+Please note that you must use the same version (channel) that you built Flutter embedder for. I recommend that you use the latest version of the master channel for both the SDK and Flutter Engine.
+See also: [Building Flutter Engine embedder](./BUILDING-ENGINE-EMBEDDER.md)
+
+### Build Flutter app
 
 Here introduce how to build the flutter sample app.
 
@@ -197,7 +197,7 @@ $ cd ..
 
 Comming soon. We are contributing to support this now. See: https://github.com/flutter/flutter/issues/74929
 
-### Run Fluter app
+### Run Flutter app
 
 Wayland compositor (weston) must be running before running the program when you use the Wayland backend.
 

--- a/README.md
+++ b/README.md
@@ -170,10 +170,14 @@ Please edit `cmake/user_config.cmake` file.
 
 Please note that you must use the same version that you built Flutter embedder for. See also: [Building Flutter Engine embedder](./BUILDING-ENGINE-EMBEDDER.md)
 
+In tearms of Flutter SDK, see also: [Desktop support for Flutter](https://flutter.dev/desktop)
+
 ```Shell
 $ git clone https://github.com/flutter/flutter
 $ sudo mv flutter /opt/
 $ export PATH=$PATH:/opt/flutter/bin
+$ flutter config --enable-linux-desktop
+$ flutter doctor
 ```
 
 ### Build your Flutter app


### PR DESCRIPTION
I added the description and the link of Flutter SDK to build linux apps.