### PR TITLE
Change output log level when the off-screen surface creation failed

### DIFF
--- a/src/flutter/shell/platform/linux_embedded/surface/context_egl.h
+++ b/src/flutter/shell/platform/linux_embedded/surface/context_egl.h
@@ -92,8 +92,8 @@ class ContextEgl {
     EGLSurface surface = eglCreateWindowSurface(
         environment_->Display(), config_, window_resource->Window(), attribs);
     if (surface == EGL_NO_SURFACE) {
-      LINUXES_LOG(ERROR) << "Failed to create EGL off-screen surface."
-                         << "(" << get_egl_error_cause() << ")";
+      LINUXES_LOG(WARNING) << "Failed to create EGL off-screen surface."
+                           << "(" << get_egl_error_cause() << ")";
     }
     return std::make_unique<LinuxesEGLSurface>(surface, environment_->Display(),
                                                resource_context_);

--- a/src/flutter/shell/platform/linux_embedded/surface/linuxes_surface_gl_drm.h
+++ b/src/flutter/shell/platform/linux_embedded/surface/linuxes_surface_gl_drm.h
@@ -47,7 +47,7 @@ class SurfaceGlDrm final : public Surface<gbm_surface, gbm_surface>,
   bool SetNativeWindowResource(NativeWindow<gbm_surface, gbm_surface>* window) {
     offscreen_surface_ = context_->CreateOffscreenSurface(window);
     if (!offscreen_surface_->IsValid()) {
-      LINUXES_LOG(ERROR) << "Off-Screen surface is invalid.";
+      LINUXES_LOG(WARNING) << "Off-Screen surface is invalid.";
       offscreen_surface_ = nullptr;
       return false;
     }

--- a/src/flutter/shell/platform/linux_embedded/surface/linuxes_surface_gl_wayland.h
+++ b/src/flutter/shell/platform/linux_embedded/surface/linuxes_surface_gl_wayland.h
@@ -51,7 +51,7 @@ class SurfaceGlWayland final : public Surface<wl_egl_window, wl_surface>,
     offscreen_surface_ =
         context_->CreateOffscreenSurface(native_window_resource_.get());
     if (!offscreen_surface_->IsValid()) {
-      LINUXES_LOG(ERROR) << "Off-Screen surface is invalid.";
+      LINUXES_LOG(WARNING) << "Off-Screen surface is invalid.";
       offscreen_surface_ = nullptr;
       return false;
     }


### PR DESCRIPTION
## Description
I changed the output log level of the process off-screen from error to warning. Because the off-screen surface is not mandatory, but it affects graphics performance.

```
[ERROR][context_egl.h(95)] Failed to create EGL off-screen surface.(eglGetError: EGL_BAD_ALLOC)
[ERROR][linuxes_surface_gl_drm.h(50)] Off-Screen surface is invalid.
```

## Related issues
- https://github.com/sony/flutter-embedded-linux/issues/4