### PR TITLE
Fix debug mode not working on the DRM backend.

### DIFF
--- a/src/flutter/shell/platform/linux_embedded/window/linuxes_window_drm.cc
+++ b/src/flutter/shell/platform/linux_embedded/window/linuxes_window_drm.cc
@@ -89,7 +89,8 @@ bool LinuxesWindowDrm::IsValid() const {
 }
 
 bool LinuxesWindowDrm::DispatchEvent() {
-  sd_event_run(libinput_event_loop_, -1);
+  constexpr uint64_t kMaxWaitTime = 0;
+  sd_event_run(libinput_event_loop_, kMaxWaitTime);
   return true;
 }
 

--- a/src/flutter/shell/platform/linux_embedded/window/linuxes_window_drm.cc
+++ b/src/flutter/shell/platform/linux_embedded/window/linuxes_window_drm.cc
@@ -70,15 +70,10 @@ LinuxesWindowDrm::LinuxesWindowDrm(FlutterWindowMode window_mode, int32_t width,
     libinput_event_loop_ = sd_event_unref(libinput_event_loop_);
     return;
   }
-
-  std::thread thread(RunLibinputEventLoop, this);
-  thread.swap(thread_);
 }
 
 LinuxesWindowDrm::~LinuxesWindowDrm() {
   if (libinput_event_loop_) {
-    sd_event_exit(libinput_event_loop_, 0);
-    thread_.join();
     sd_event_unref(libinput_event_loop_);
   }
   libinput_unref(libinput_);
@@ -94,7 +89,7 @@ bool LinuxesWindowDrm::IsValid() const {
 }
 
 bool LinuxesWindowDrm::DispatchEvent() {
-  // do nothing.
+  sd_event_run(libinput_event_loop_, -1);
   return true;
 }
 
@@ -175,12 +170,6 @@ std::string LinuxesWindowDrm::GetClipboardData() { return clipboard_data_; }
 
 void LinuxesWindowDrm::SetClipboardData(const std::string& data) {
   clipboard_data_ = data;
-}
-
-// static
-void LinuxesWindowDrm::RunLibinputEventLoop(void* data) {
-  auto self = reinterpret_cast<LinuxesWindowDrm*>(data);
-  sd_event_loop(self->libinput_event_loop_);
 }
 
 // static

--- a/src/flutter/shell/platform/linux_embedded/window/linuxes_window_drm.h
+++ b/src/flutter/shell/platform/linux_embedded/window/linuxes_window_drm.h
@@ -61,7 +61,6 @@ class LinuxesWindowDrm : public LinuxesWindow, public WindowBindingHandler {
   void SetClipboardData(const std::string& data) override;
 
  private:
-  static void RunLibinputEventLoop(void* data);
   static int OnLibinputEvent(sd_event_source* source, int fd, uint32_t revents,
                              void* data);
   void OnDeviceAdded(libinput_event* event);
@@ -92,7 +91,6 @@ class LinuxesWindowDrm : public LinuxesWindow, public WindowBindingHandler {
 
   sd_event* libinput_event_loop_;
   libinput* libinput_;
-  std::thread thread_;
 };
 
 }  // namespace flutter


### PR DESCRIPTION
# Description
The Flutter engine asserts that it receives an event from a different thread than the main thread. (This feature is valid only in debug mode)  
On the DRM backend, a sub-thread was created to receive the libinput event.  This was the cause of this issue.

I fixed it to receive the libinput event on the main thread.
I verified that the DRM backend works in debug mode on x64 Ubuntu and Raspberry Pi4.

# Related issues
#33 
