### PR TITLE
Refactor native window template

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -14,7 +14,9 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Install libraries
-      run: sudo apt install libgles2-mesa-dev libegl1-mesa-dev libxkbcommon-dev libwayland-dev libdrm-dev libgbm-dev libinput-dev libudev-dev libsystemd-dev wayland-protocols
+      run: |
+        sudo apt update
+        sudo apt install libgles2-mesa-dev libegl1-mesa-dev libxkbcommon-dev libwayland-dev libdrm-dev libgbm-dev libinput-dev libudev-dev libsystemd-dev wayland-protocols
 
     - name: Install Flutter Engine library
       run: |

--- a/src/flutter/shell/platform/linux_embedded/surface/context_egl.h
+++ b/src/flutter/shell/platform/linux_embedded/surface/context_egl.h
@@ -17,7 +17,7 @@
 
 namespace flutter {
 
-template <typename D, typename W, typename S>
+template <typename D, typename W>
 class ContextEgl {
  public:
   ContextEgl(std::unique_ptr<EnvironmentEgl<D>> environment)
@@ -72,7 +72,7 @@ class ContextEgl {
   ~ContextEgl() = default;
 
   std::unique_ptr<LinuxesEGLSurface> CreateOnscreenSurface(
-      NativeWindow<W, S>* window) const {
+      NativeWindow<W>* window) const {
     const EGLint attribs[] = {EGL_NONE};
     EGLSurface surface = eglCreateWindowSurface(
         environment_->Display(), config_, window->Window(), attribs);
@@ -85,7 +85,7 @@ class ContextEgl {
   }
 
   std::unique_ptr<LinuxesEGLSurface> CreateOffscreenSurface(
-      NativeWindow<W, S>* window_resource) const {
+      NativeWindow<W>* window_resource) const {
     // eglCreatePbufferSurface isn't supported on both Wayland and GBM.
     // Therefore, we neet to create a dummy wl_egl_window when we use Wayland.
     const EGLint attribs[] = {EGL_NONE};

--- a/src/flutter/shell/platform/linux_embedded/surface/context_egl_drm.h
+++ b/src/flutter/shell/platform/linux_embedded/surface/context_egl_drm.h
@@ -13,7 +13,7 @@
 
 namespace flutter {
 
-using ContextEglDrm = ContextEgl<gbm_device, gbm_surface, gbm_surface>;
+using ContextEglDrm = ContextEgl<gbm_device, gbm_surface>;
 
 }  // namespace flutter
 

--- a/src/flutter/shell/platform/linux_embedded/surface/context_egl_wayland.h
+++ b/src/flutter/shell/platform/linux_embedded/surface/context_egl_wayland.h
@@ -11,7 +11,7 @@
 
 namespace flutter {
 
-using ContextEglWayland = ContextEgl<wl_display, wl_egl_window, wl_surface>;
+using ContextEglWayland = ContextEgl<wl_display, wl_egl_window>;
 
 }  // namespace flutter
 

--- a/src/flutter/shell/platform/linux_embedded/surface/linuxes_surface.h
+++ b/src/flutter/shell/platform/linux_embedded/surface/linuxes_surface.h
@@ -11,14 +11,14 @@
 
 namespace flutter {
 
-template <typename W, typename S>
+template <typename T>
 class Surface {
  public:
   // Shows a surface is valid or not.
   virtual bool IsValid() const = 0;
 
   // Sets a netive platform's window.
-  virtual bool SetNativeWindow(NativeWindow<W, S>* window) = 0;
+  virtual bool SetNativeWindow(NativeWindow<T>* window) = 0;
 
   // Changes an on-screen surface size.
   virtual bool OnScreenSurfaceResize(const size_t width,

--- a/src/flutter/shell/platform/linux_embedded/surface/linuxes_surface_gl_drm.cc
+++ b/src/flutter/shell/platform/linux_embedded/surface/linuxes_surface_gl_drm.cc
@@ -17,8 +17,7 @@ bool SurfaceGlDrm::IsValid() const {
   return offscreen_surface_ && context_->IsValid();
 }
 
-bool SurfaceGlDrm::SetNativeWindow(
-    NativeWindow<gbm_surface, gbm_surface>* window) {
+bool SurfaceGlDrm::SetNativeWindow(NativeWindow<gbm_surface>* window) {
   native_window_ = window;
   onscreen_surface_ = context_->CreateOnscreenSurface(native_window_);
   if (!onscreen_surface_->IsValid()) {
@@ -27,8 +26,7 @@ bool SurfaceGlDrm::SetNativeWindow(
   return true;
 }
 
-bool SurfaceGlDrm::SetNativeWindowResource(
-    NativeWindow<gbm_surface, gbm_surface>* window) {
+bool SurfaceGlDrm::SetNativeWindowResource(NativeWindow<gbm_surface>* window) {
   offscreen_surface_ = context_->CreateOffscreenSurface(window);
   if (!offscreen_surface_->IsValid()) {
     LINUXES_LOG(WARNING) << "Off-Screen surface is invalid.";

--- a/src/flutter/shell/platform/linux_embedded/surface/linuxes_surface_gl_drm.h
+++ b/src/flutter/shell/platform/linux_embedded/surface/linuxes_surface_gl_drm.h
@@ -17,7 +17,7 @@
 
 namespace flutter {
 
-class SurfaceGlDrm final : public Surface<gbm_surface, gbm_surface>,
+class SurfaceGlDrm final : public Surface<gbm_surface>,
                            public SurfaceGlDelegate {
  public:
   SurfaceGlDrm(std::unique_ptr<ContextEglDrm> context);
@@ -27,12 +27,13 @@ class SurfaceGlDrm final : public Surface<gbm_surface, gbm_surface>,
   bool IsValid() const override;
 
   // |Surface|
-  bool SetNativeWindow(NativeWindow<gbm_surface, gbm_surface>* window) override;
+  bool SetNativeWindow(NativeWindow<gbm_surface>* window) override;
 
-  bool SetNativeWindowResource(NativeWindow<gbm_surface, gbm_surface>* window);
+  bool SetNativeWindowResource(NativeWindow<gbm_surface>* window);
 
   // |Surface|
-  bool OnScreenSurfaceResize(const size_t width, const size_t height) const override;
+  bool OnScreenSurfaceResize(const size_t width,
+                             const size_t height) const override;
 
   // |Surface|
   void DestroyOnScreenContext() override;
@@ -60,7 +61,7 @@ class SurfaceGlDrm final : public Surface<gbm_surface, gbm_surface>,
 
  private:
   std::unique_ptr<ContextEglDrm> context_;
-  NativeWindow<gbm_surface, gbm_surface>* native_window_;
+  NativeWindow<gbm_surface>* native_window_;
   std::unique_ptr<LinuxesEGLSurface> onscreen_surface_;
   std::unique_ptr<LinuxesEGLSurface> offscreen_surface_;
 };

--- a/src/flutter/shell/platform/linux_embedded/surface/linuxes_surface_gl_wayland.cc
+++ b/src/flutter/shell/platform/linux_embedded/surface/linuxes_surface_gl_wayland.cc
@@ -19,8 +19,7 @@ bool SurfaceGlWayland::IsValid() const {
   return offscreen_surface_ && context_->IsValid();
 }
 
-bool SurfaceGlWayland::SetNativeWindow(
-    NativeWindow<wl_egl_window, wl_surface>* window) {
+bool SurfaceGlWayland::SetNativeWindow(NativeWindow<wl_egl_window>* window) {
   native_window_ = window;
   onscreen_surface_ = context_->CreateOnscreenSurface(native_window_);
   if (!onscreen_surface_->IsValid()) {
@@ -30,7 +29,7 @@ bool SurfaceGlWayland::SetNativeWindow(
 }
 
 bool SurfaceGlWayland::SetNativeWindowResource(
-    std::unique_ptr<NativeWindow<wl_egl_window, wl_surface>> window) {
+    std::unique_ptr<NativeWindow<wl_egl_window>> window) {
   native_window_resource_ = std::move(window);
   offscreen_surface_ =
       context_->CreateOffscreenSurface(native_window_resource_.get());

--- a/src/flutter/shell/platform/linux_embedded/surface/linuxes_surface_gl_wayland.h
+++ b/src/flutter/shell/platform/linux_embedded/surface/linuxes_surface_gl_wayland.h
@@ -16,7 +16,7 @@
 
 namespace flutter {
 
-class SurfaceGlWayland final : public Surface<wl_egl_window, wl_surface>,
+class SurfaceGlWayland final : public Surface<wl_egl_window>,
                                public SurfaceGlDelegate {
  public:
   SurfaceGlWayland(std::unique_ptr<ContextEglWayland> context);
@@ -26,11 +26,10 @@ class SurfaceGlWayland final : public Surface<wl_egl_window, wl_surface>,
   bool IsValid() const override;
 
   // |Surface|
-  bool SetNativeWindow(
-      NativeWindow<wl_egl_window, wl_surface>* window) override;
+  bool SetNativeWindow(NativeWindow<wl_egl_window>* window) override;
 
   bool SetNativeWindowResource(
-      std::unique_ptr<NativeWindow<wl_egl_window, wl_surface>> window);
+      std::unique_ptr<NativeWindow<wl_egl_window>> window);
 
   // |Surface|
   bool OnScreenSurfaceResize(const size_t width,
@@ -62,9 +61,8 @@ class SurfaceGlWayland final : public Surface<wl_egl_window, wl_surface>,
 
  private:
   std::unique_ptr<ContextEglWayland> context_;
-  NativeWindow<wl_egl_window, wl_surface>* native_window_;
-  std::unique_ptr<NativeWindow<wl_egl_window, wl_surface>>
-      native_window_resource_;
+  NativeWindow<wl_egl_window>* native_window_;
+  std::unique_ptr<NativeWindow<wl_egl_window>> native_window_resource_;
   std::unique_ptr<LinuxesEGLSurface> onscreen_surface_;
   std::unique_ptr<LinuxesEGLSurface> offscreen_surface_;
 };

--- a/src/flutter/shell/platform/linux_embedded/surface/native_window.h
+++ b/src/flutter/shell/platform/linux_embedded/surface/native_window.h
@@ -7,7 +7,7 @@
 
 namespace flutter {
 
-template <typename W, typename S>
+template <typename W>
 class NativeWindow {
  public:
   NativeWindow() = default;
@@ -17,13 +17,10 @@ class NativeWindow {
 
   W* Window() const { return window_; }
 
-  S* Surface() const { return surface_; }
-
   virtual bool Resize(const size_t width, const size_t height) const = 0;
 
  protected:
   W* window_ = nullptr;
-  S* surface_ = nullptr;
   bool valid_ = false;
 };
 

--- a/src/flutter/shell/platform/linux_embedded/surface/native_window.h
+++ b/src/flutter/shell/platform/linux_embedded/surface/native_window.h
@@ -20,7 +20,9 @@ class NativeWindow {
   virtual bool Resize(const size_t width, const size_t height) const = 0;
 
  protected:
+  // Specifies the native winodw (NativeWindowType)
   W* window_ = nullptr;
+  
   bool valid_ = false;
 };
 

--- a/src/flutter/shell/platform/linux_embedded/surface/native_window_drm.cc
+++ b/src/flutter/shell/platform/linux_embedded/surface/native_window_drm.cc
@@ -43,15 +43,13 @@ NativeWindowDrm::NativeWindowDrm(const char* deviceFilename) {
     return;
   }
 
-  surface_ = gbm_surface_create(gbm_device_, drm_mode_info_.hdisplay,
-                                drm_mode_info_.vdisplay, GBM_BO_FORMAT_ARGB8888,
-                                GBM_BO_USE_SCANOUT | GBM_BO_USE_RENDERING);
-  if (!surface_) {
-    LINUXES_LOG(ERROR) << "Failed to create the compositor surface.";
+  window_ = gbm_surface_create(gbm_device_, drm_mode_info_.hdisplay,
+                               drm_mode_info_.vdisplay, GBM_BO_FORMAT_ARGB8888,
+                               GBM_BO_USE_SCANOUT | GBM_BO_USE_RENDERING);
+  if (!window_) {
+    LINUXES_LOG(ERROR) << "Failed to create the gbm surface.";
     return;
   }
-
-  window_ = surface_;
 
   valid_ = true;
 }
@@ -75,9 +73,9 @@ NativeWindowDrm::~NativeWindowDrm() {
 
   if (gbm_previous_bo_) {
     drmModeRmFB(drm_device_, gbm_previous_fb_);
-    gbm_surface_release_buffer(surface_, gbm_previous_bo_);
-    gbm_surface_destroy(surface_);
-    surface_ = nullptr;
+    gbm_surface_release_buffer(window_, gbm_previous_bo_);
+    gbm_surface_destroy(window_);
+    window_ = nullptr;
   }
 
   if (gbm_device_) {
@@ -100,7 +98,7 @@ bool NativeWindowDrm::Resize(const size_t width, const size_t height) const {
 }
 
 void NativeWindowDrm::SwapBuffer() {
-  auto* bo = gbm_surface_lock_front_buffer(surface_);
+  auto* bo = gbm_surface_lock_front_buffer(window_);
   auto width = gbm_bo_get_width(bo);
   auto height = gbm_bo_get_height(bo);
   auto handle = gbm_bo_get_handle(bo).u32;
@@ -119,7 +117,7 @@ void NativeWindowDrm::SwapBuffer() {
 
   if (gbm_previous_bo_) {
     drmModeRmFB(drm_device_, gbm_previous_fb_);
-    gbm_surface_release_buffer(surface_, gbm_previous_bo_);
+    gbm_surface_release_buffer(window_, gbm_previous_bo_);
   }
   gbm_previous_bo_ = bo;
   gbm_previous_fb_ = fb;

--- a/src/flutter/shell/platform/linux_embedded/surface/native_window_drm.h
+++ b/src/flutter/shell/platform/linux_embedded/surface/native_window_drm.h
@@ -15,7 +15,7 @@
 
 namespace flutter {
 
-class NativeWindowDrm : public NativeWindow<gbm_surface, gbm_surface> {
+class NativeWindowDrm : public NativeWindow<gbm_surface> {
  public:
   NativeWindowDrm(const char* deviceFilename);
   ~NativeWindowDrm();

--- a/src/flutter/shell/platform/linux_embedded/surface/native_window_wayland.h
+++ b/src/flutter/shell/platform/linux_embedded/surface/native_window_wayland.h
@@ -11,7 +11,7 @@
 
 namespace flutter {
 
-class NativeWindowWayland : public NativeWindow<wl_egl_window, wl_surface> {
+class NativeWindowWayland : public NativeWindow<wl_egl_window> {
  public:
   NativeWindowWayland(wl_compositor* compositor, const size_t width,
                       const size_t height);
@@ -19,6 +19,11 @@ class NativeWindowWayland : public NativeWindow<wl_egl_window, wl_surface> {
 
   // |NativeWindow|
   bool Resize(const size_t width, const size_t height) const override;
+
+  wl_surface* Surface() const { return surface_; }
+
+ private:
+  wl_surface* surface_ = nullptr;
 };
 
 }  // namespace flutter


### PR DESCRIPTION
Refactor source files before adding X11 backend support. I needed to specify the dummy variable type (`gbm_surface`) in the DRM backend when I use the common template even though `Surface` in `native_window.h` is only used by the Wayland backend.

In addition, I fixed the following GitHub Actions error.
```
Err:24 http://azure.archive.ubuntu.com/ubuntu focal-updates/main amd64 libsystemd-dev amd64 245.4-4ubuntu3.4
  404  Not Found [IP: 40.119.46.219 80]
Err:25 http://azure.archive.ubuntu.com/ubuntu focal-updates/main amd64 libudev-dev amd64 245.4-4ubuntu3.4
  404  Not Found [IP: 40.119.46.219 80]
Get:26 http://azure.archive.ubuntu.com/ubuntu focal/main amd64 libwacom-bin amd64 1.3-2ubuntu1 [5484 B]
Get:27 http://azure.archive.ubuntu.com/ubuntu focal/main amd64 libwacom-dev amd64 1.3-2ubuntu1 [6972 B]
Get:28 http://azure.archive.ubuntu.com/ubuntu focal/main amd64 libxkbcommon-dev amd64 0.10.0-1 [45.4 kB]
Get:29 http://azure.archive.ubuntu.com/ubuntu focal-updates/main amd64 libevdev-dev amd64 1.9.0+dfsg-1ubuntu0.1 [48.7 kB]
Get:30 http://azure.archive.ubuntu.com/ubuntu focal-updates/main amd64 libinput-dev amd64 1.15.5-1ubuntu0.2 [29.7 kB]
Get:31 http://azure.archive.ubuntu.com/ubuntu focal/main amd64 libwayland-bin amd64 1.18.0-1 [20.3 kB]
Get:32 http://azure.archive.ubuntu.com/ubuntu focal/main amd64 libwayland-dev amd64 1.18.0-1 [64.6 kB]
Get:33 http://azure.archive.ubuntu.com/ubuntu focal/main amd64 wayland-protocols all 1.20-1 [60.3 kB]
E: Failed to fetch http://azure.archive.ubuntu.com/ubuntu/pool/main/s/systemd/libsystemd-dev_245.4-4ubuntu3.4_amd64.deb  404  Not Found [IP: 40.119.46.219 80]
Fetched 1074 kB in 1s (1650 kB/s)
E: Failed to fetch http://azure.archive.ubuntu.com/ubuntu/pool/main/s/systemd/libudev-dev_245.4-4ubuntu3.4_amd64.deb  404  Not Found [IP: 40.119.46.219 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
Error: Process completed with exit code 100.
```