### PR TITLE
Add mouse events support on x11

### DIFF
--- a/src/flutter/shell/platform/linux_embedded/surface/native_window_x11.cc
+++ b/src/flutter/shell/platform/linux_embedded/surface/native_window_x11.cc
@@ -36,9 +36,11 @@ NativeWindowX11::NativeWindowX11(Display* display, const size_t width,
   window_ = xcb_generate_id(xcb_connection_);
 
   uint32_t mask = XCB_CW_EVENT_MASK;
-  uint32_t valwin[1] = {XCB_EVENT_MASK_EXPOSURE |
-                        XCB_EVENT_MASK_RESIZE_REDIRECT |
-                        XCB_EVENT_MASK_STRUCTURE_NOTIFY};
+  uint32_t valwin[1] = {
+      XCB_EVENT_MASK_EXPOSURE | XCB_EVENT_MASK_RESIZE_REDIRECT |
+      XCB_EVENT_MASK_STRUCTURE_NOTIFY | XCB_EVENT_MASK_BUTTON_PRESS |
+      XCB_EVENT_MASK_BUTTON_RELEASE | XCB_EVENT_MASK_POINTER_MOTION |
+      XCB_EVENT_MASK_ENTER_WINDOW | XCB_EVENT_MASK_LEAVE_WINDOW};
   xcb_create_window(xcb_connection_, XCB_COPY_FROM_PARENT, window_,
                     screen_iterator->root, 0, 0, width, height, 0,
                     XCB_WINDOW_CLASS_INPUT_OUTPUT, screen_iterator->root_visual,

--- a/src/flutter/shell/platform/linux_embedded/window/linuxes_window_x11.cc
+++ b/src/flutter/shell/platform/linux_embedded/window/linuxes_window_x11.cc
@@ -194,7 +194,8 @@ void LinuxesWindowX11::HandlePointerButtonEvent(xcb_button_t button,
         flutter_button = kFlutterPointerButtonMouseForward;
         break;
       default:
-        break;
+        LINUXES_LOG(ERROR) << "Not expected button input: " << button;
+        return;
     }
     if (button_pressed) {
       binding_handler_delegate_->OnPointerDown(x, y, flutter_button);

--- a/src/flutter/shell/platform/linux_embedded/window/linuxes_window_x11.cc
+++ b/src/flutter/shell/platform/linux_embedded/window/linuxes_window_x11.cc
@@ -13,6 +13,14 @@
 
 namespace flutter {
 
+namespace {
+static constexpr uint8_t kButtonLeft = 1;
+static constexpr uint8_t kButtonMiddle = 2;
+static constexpr uint8_t kButtonRight = 3;
+static constexpr uint8_t kButtonBack = 4;
+static constexpr uint8_t kButtonForward = 5;
+}  // namespace
+
 LinuxesWindowX11::LinuxesWindowX11(FlutterWindowMode window_mode, int32_t width,
                                    int32_t height, bool show_cursor) {
   window_mode_ = window_mode;
@@ -48,10 +56,37 @@ bool LinuxesWindowX11::IsValid() const {
 bool LinuxesWindowX11::DispatchEvent() {
   auto connection = native_window_->XcbConnection();
 
-  // TODO: support events such as button inputs and mouse move.
+  // TODO: support events such as keyboard input.
   xcb_generic_event_t* event;
   while ((event = xcb_poll_for_event(connection)) != NULL) {
     switch (event->response_type & ~0x80) {
+      case XCB_BUTTON_PRESS: {
+        auto* ev = reinterpret_cast<xcb_button_press_event_t*>(event);
+        constexpr bool button_pressed = true;
+        HandlePointerButtonEvent(ev->detail, button_pressed, ev->event_x,
+                                 ev->event_y);
+        break;
+      }
+      case XCB_BUTTON_RELEASE: {
+        auto* ev = reinterpret_cast<xcb_button_release_event_t*>(event);
+        constexpr bool button_pressed = false;
+        HandlePointerButtonEvent(ev->detail, button_pressed, ev->event_x,
+                                 ev->event_y);
+        break;
+      }
+      case XCB_ENTER_NOTIFY: {
+        auto* ev = reinterpret_cast<xcb_enter_notify_event_t*>(event);
+        binding_handler_delegate_->OnPointerMove(ev->event_x, ev->event_y);
+        break;
+      }
+      case XCB_MOTION_NOTIFY: {
+        auto* ev = reinterpret_cast<xcb_motion_notify_event_t*>(event);
+        binding_handler_delegate_->OnPointerMove(ev->event_x, ev->event_y);
+        break;
+      }
+      case XCB_LEAVE_NOTIFY:
+        binding_handler_delegate_->OnPointerLeave();
+        break;
       case XCB_CONFIGURE_NOTIFY:
         break;
       case XCB_RESIZE_REQUEST: {
@@ -135,6 +170,38 @@ std::string LinuxesWindowX11::GetClipboardData() { return clipboard_data_; }
 
 void LinuxesWindowX11::SetClipboardData(const std::string& data) {
   clipboard_data_ = data;
+}
+
+void LinuxesWindowX11::HandlePointerButtonEvent(xcb_button_t button,
+                                                bool button_pressed, int16_t x,
+                                                int16_t y) {
+  if (binding_handler_delegate_) {
+    FlutterPointerMouseButtons flutter_button;
+    switch (button) {
+      case kButtonLeft:
+        flutter_button = kFlutterPointerButtonMousePrimary;
+        break;
+      case kButtonRight:
+        flutter_button = kFlutterPointerButtonMouseSecondary;
+        break;
+      case kButtonMiddle:
+        flutter_button = kFlutterPointerButtonMouseMiddle;
+        break;
+      case kButtonBack:
+        flutter_button = kFlutterPointerButtonMouseBack;
+        break;
+      case kButtonForward:
+        flutter_button = kFlutterPointerButtonMouseForward;
+        break;
+      default:
+        break;
+    }
+    if (button_pressed) {
+      binding_handler_delegate_->OnPointerDown(x, y, flutter_button);
+    } else {
+      binding_handler_delegate_->OnPointerUp(x, y, flutter_button);
+    }
+  }
 }
 
 }  // namespace flutter

--- a/src/flutter/shell/platform/linux_embedded/window/linuxes_window_x11.h
+++ b/src/flutter/shell/platform/linux_embedded/window/linuxes_window_x11.h
@@ -57,6 +57,10 @@ class LinuxesWindowX11 : public LinuxesWindow, public WindowBindingHandler {
   void SetClipboardData(const std::string& data) override;
 
  private:
+  // Handles the events of the mouse button.
+  void HandlePointerButtonEvent(xcb_button_t button, bool button_pressed,
+                                int16_t x, int16_t y);
+
   // A pointer to a FlutterWindowsView that can be used to update engine
   // windowing and input state.
   WindowBindingHandlerDelegate* binding_handler_delegate_;


### PR DESCRIPTION
I added mouse events support on x11.

## Related issues
- https://github.com/sony/flutter-embedded-linux/issues/37