### PR TITLE
Update debugging readme and change Flutter engine library path at build time

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -28,7 +28,7 @@ jobs:
         curl -O https://storage.googleapis.com/flutter_infra/flutter/${FLUTTER_ENGINE}/linux-x64/linux-x64-embedder
         ls
         unzip linux-x64-embedder
-        sudo mv libflutter_engine.so ./build/
+        mv libflutter_engine.so ${{github.workspace}}/build
 
     - name: Configure CMake for wayland client
       shell: bash

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -18,6 +18,9 @@ jobs:
         sudo apt update
         sudo apt install libgles2-mesa-dev libegl1-mesa-dev libxkbcommon-dev libwayland-dev libdrm-dev libgbm-dev libinput-dev libudev-dev libsystemd-dev wayland-protocols libx11-xcb-dev
 
+    - name: Create Build Environment
+      run: cmake -E make_directory ${{github.workspace}}/build
+
     - name: Install Flutter Engine library
       run: |
         echo `curl https://raw.githubusercontent.com/flutter/flutter/master/bin/internal/engine.version` > embedder.version
@@ -25,10 +28,7 @@ jobs:
         curl -O https://storage.googleapis.com/flutter_infra/flutter/${FLUTTER_ENGINE}/linux-x64/linux-x64-embedder
         ls
         unzip linux-x64-embedder
-        sudo mv libflutter_engine.so /usr/lib/
-
-    - name: Create Build Environment
-      run: cmake -E make_directory ${{github.workspace}}/build
+        sudo mv libflutter_engine.so ./build/
 
     - name: Configure CMake for wayland client
       shell: bash

--- a/BUILDING-ENGINE-EMBEDDER.md
+++ b/BUILDING-ENGINE-EMBEDDER.md
@@ -118,13 +118,22 @@ $ ninja -C out/host_release
 ## 5. Install embedder library
 
 ```Shell
-$ sudo cp ./out/linux_{your selected target and mode}/libflutter_engine.so /usr/lib
+$ sudo cp ./out/${path to your selected target and mode}/libflutter_engine.so <path_to_cmake_build_directory>
 ```
 
 ### Supplement
 
-You need to install `libflutter_engine.so` in `/usr/lib` to build. But you can switch quickly between debug / profile / release modes for the Flutter app without replacing `libflutter_engine.so` by using `LD_LIBRARY_PATH` when you run the Flutter app.
+You need to install `libflutter_engine.so` in `<path_to_cmake_build_directory>` to build. But you can switch quickly between debug / profile / release modes for the Flutter app without replacing `libflutter_engine.so` by using `LD_LIBRARY_PATH` when you run the Flutter app.
 
 ```Shell
-LD_LIBRARY_PATH=<path_to_engine> ./flutter-client ./sample/build/linux/x64/debug/bundle
+$ LD_LIBRARY_PATH=<path_to_engine> ./flutter-client <path_to_flutter_project_bundle>
+
+# e.g. Run in debug mode
+$ LD_LIBRARY_PATH=/usr/lib/flutter_engine/debug/ ./flutter-client ./sample/build/linux/x64/debug/bundle
+
+# e.g. Run in profile mode
+$ LD_LIBRARY_PATH=/usr/lib/flutter_engine/profile/ ./flutter-client ./sample/build/linux/x64/profile/bundle
+
+# e.g. Run in release mode
+$ LD_LIBRARY_PATH=/usr/lib/flutter_engine/release/ ./flutter-client ./sample/build/linux/x64/release/bundle
 ```

--- a/DEBUGGING.md
+++ b/DEBUGGING.md
@@ -1,0 +1,36 @@
+# How to debug Flutter apps
+It is possible to do most things, including source-level debugging, profiling and hot reload when you debug Flutter apps on this embedder. Naturally, you need to use `libflutter_engine.so` built with debug mode.
+
+## Getting the Observatory port
+
+You will find the following message in the console when you run Flutter apps. You need to attach a debugger to this port when you want to debug it. Note that the URI changes every time after launching.
+
+```Shell
+flutter: Observatory listening on http://127.0.0.1:40409/k8IUol2dnPI=/
+```
+## Debugging
+
+### Command line
+
+```Shell:
+$ flutter attach --device-id=flutter-tester --debug-uri http://127.0.0.1:40409/k8IUol2dnPI=/
+```
+
+### VS Code
+
+Create a [launch.json file](https://code.visualstudio.com/docs/editor/debugging#_launch-configurations) like the following.
+
+```Json:
+{
+  "version": "0.2.0"
+  "configurations": [
+    {
+      "type": "dart",
+      "name": "Flutter Embedded Linux Attach",
+      "request": "attach",
+      "deviceId": "flutter-tester",
+      "observatoryUri": "http://127.0.0.1:40409/k8IUol2dnPI=/"
+    }
+  ]
+}
+```

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ There are sample projects in [`examples`](./examples) directory. You can also co
 $ mkdir build
 $ cd build
 $ cmake -DUSER_PROJECT_PATH=examples/flutter-wayland-client ..
-$ make
+$ cmake --build .
 ```
 
 ### Build for DRM backend
@@ -167,7 +167,7 @@ $ make
 $ mkdir build
 $ cd build
 $ cmake -DUSER_PROJECT_PATH=examples/flutter-drm-backend ..
-$ make
+$ cmake --build .
 ```
 
 ### Build for x11 backend
@@ -178,7 +178,7 @@ Basically, the x11 backend is just only for debugging and developing Flutter app
 $ mkdir build
 $ cd build
 $ cmake -DUSER_PROJECT_PATH=examples/flutter-x11-client ..
-$ make
+$ cmake --build .
 ```
 
 ### Build for Wayland backend (Weston desktop-shell)
@@ -189,7 +189,7 @@ This binary will run as a desktop-shell by setting `weston.ini` when Weston star
 $ mkdir build
 $ cd build
 $ cmake -DUSER_PROJECT_PATH=examples/flutter-weston-desktop-shell ..
-$ make
+$ cmake --build .
 ```
 
 ### User configuration parameters (CMAKE options)

--- a/README.md
+++ b/README.md
@@ -275,11 +275,11 @@ $ sudo FLUTTER_DRM_DEVICE="/dev/dri/card1" ./flutter-drm-backend ./sample/build/
 
 If you want to switch back from CUI to GUI, run `Ctrl + Alt + F2` keys in a terminal.
 
-### Debugging
-You can do debugging Flutter apps. Please see: [How to debug Flutter apps](./DEBUGGING.md)
-
 ##### Note
 You need to run this program by a user who has the permission to access the input devices(/dev/input/xxx), if you use the DRM backend. Generally, it is a root user or a user who belongs to an input group.
+
+### Debugging
+You can do debugging Flutter apps. Please see: [How to debug Flutter apps](./DEBUGGING.md)
 
 ## 5. Settings of weston.ini file (Only when you use Weston desktop-shell)
 

--- a/README.md
+++ b/README.md
@@ -247,9 +247,6 @@ Wayland compositor such as Weston must be running before running the program.
 $ ./flutter-client ./sample/build/linux/x64/release/bundle
 ```
 
-### Debugging
-You can do debugging Flutter apps. Please see: [How to debug Flutter apps](./DEBUGGING.md)
-
 #### Supplement
 
 You can switch quickly between debug / profile / release modes for the Flutter app without replacing `libflutter_engine.so` by using `LD_LIBRARY_PATH` when you run the Flutter app.
@@ -277,6 +274,9 @@ $ sudo FLUTTER_DRM_DEVICE="/dev/dri/card1" ./flutter-drm-backend ./sample/build/
 ```
 
 If you want to switch back from CUI to GUI, run `Ctrl + Alt + F2` keys in a terminal.
+
+### Debugging
+You can do debugging Flutter apps. Please see: [How to debug Flutter apps](./DEBUGGING.md)
 
 ##### Note
 You need to run this program by a user who has the permission to access the input devices(/dev/input/xxx), if you use the DRM backend. Generally, it is a root user or a user who belongs to an input group.

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ See also: [Contributing to the Flutter engine](https://github.com/flutter/engine
 
 ## 1. Install libraries
 
-You need to install the following dependent libraries to build and run. Here introduce how to install the libraries on Ubuntu OS and x64 hosts.
+You need to install the following dependent libraries to build and run. Here introduce how to install the libraries on Debian-based systems like Ubuntu.
 
 #### Mandatory
 
@@ -252,7 +252,16 @@ $ ./flutter-client ./sample/build/linux/x64/release/bundle
 You can switch quickly between debug / profile / release modes for the Flutter app without replacing `libflutter_engine.so` by using `LD_LIBRARY_PATH` when you run the Flutter app.
 
 ```Shell
-LD_LIBRARY_PATH=<path_to_engine> ./flutter-client ./sample/build/linux/x64/debug/bundle
+$ LD_LIBRARY_PATH=<path_to_engine> ./flutter-client <path_to_flutter_project_bundle>
+
+# e.g. Run in debug mode
+$ LD_LIBRARY_PATH=/usr/lib/flutter_engine/debug/ ./flutter-client ./sample/build/linux/x64/debug/bundle
+
+# e.g. Run in profile mode
+$ LD_LIBRARY_PATH=/usr/lib/flutter_engine/profile/ ./flutter-client ./sample/build/linux/x64/profile/bundle
+
+# e.g. Run in release mode
+$ LD_LIBRARY_PATH=/usr/lib/flutter_engine/release/ ./flutter-client ./sample/build/linux/x64/release/bundle
 ```
 
 #### Run with DRM backend
@@ -261,7 +270,7 @@ You need to switch from GUI which is running X11 or Wayland to the Character Use
 
 ```Shell
 $ Ctrl + Alt + F3 # Switching to CUI
-$ FLUTTER_DRM_DEVICE="/dev/dri/card1" ./flutter-drm-backend ./sample/build/linux/x64/release/bundle
+$ sudo FLUTTER_DRM_DEVICE="/dev/dri/card1" ./flutter-drm-backend ./sample/build/linux/x64/release/bundle
 ```
 
 If you want to switch back from CUI to GUI, run `Ctrl + Alt + F2` keys in a terminal.

--- a/README.md
+++ b/README.md
@@ -247,6 +247,9 @@ Wayland compositor such as Weston must be running before running the program.
 $ ./flutter-client ./sample/build/linux/x64/release/bundle
 ```
 
+### Debugging
+You can do debugging Flutter apps. Please see: [How to debug Flutter apps](./DEBUGGING.md)
+
 #### Supplement
 
 You can switch quickly between debug / profile / release modes for the Flutter app without replacing `libflutter_engine.so` by using `LD_LIBRARY_PATH` when you run the Flutter app.

--- a/cmake/build.cmake
+++ b/cmake/build.cmake
@@ -126,7 +126,7 @@ target_include_directories(${TARGET}
 )
 
 set(CMAKE_SKIP_RPATH true)
-set(FLUTTER_EMBEDDER_LIB libflutter_engine.so)
+set(FLUTTER_EMBEDDER_LIB ${CMAKE_CURRENT_SOURCE_DIR}/build/libflutter_engine.so)
 target_link_libraries(${TARGET}
   PRIVATE
     ${XKBCOMMON_LIBRARIES}

--- a/cmake/build.cmake
+++ b/cmake/build.cmake
@@ -126,7 +126,7 @@ target_include_directories(${TARGET}
 )
 
 set(CMAKE_SKIP_RPATH true)
-set(FLUTTER_EMBEDDER_LIB /usr/lib/libflutter_engine.so)
+set(FLUTTER_EMBEDDER_LIB libflutter_engine.so)
 target_link_libraries(${TARGET}
   PRIVATE
     ${XKBCOMMON_LIBRARIES}


### PR DESCRIPTION
I've changed the following things.

- Added how to debug Flutter apps into README
- Changed Flutter engine library path at build time

## Related issues
- https://github.com/sony/flutter-embedded-linux/issues/24