### PR TITLE
Support debug mode

### DIFF
--- a/DEBUGGING.md
+++ b/DEBUGGING.md
@@ -26,7 +26,7 @@ $ flutter attach --device-id=flutter-tester --debug-uri http://127.0.0.1:40409/k
 ```
 
 ### How to use command line options in the Dart VM
-You can use the environment variables such as `FLUTTER_ENGINE_SWITCHES`, `FLUTTER_ENGINE_SWITCH_*` to use Dart VM command line options. If you want to fix always same observatory RUI, you can use the following command.
+You can use the environment variables such as `FLUTTER_ENGINE_SWITCHES`, `FLUTTER_ENGINE_SWITCH_*` to use Dart VM command line options. If you want to fix always same observatory URI, you can use the following command.
 
 ```Shell
 $ FLUTTER_ENGINE_SWITCHES=2 \

--- a/DEBUGGING.md
+++ b/DEBUGGING.md
@@ -25,7 +25,7 @@ flutter: Observatory listening on http://127.0.0.1:40409/k8IUol2dnPI=/
 $ flutter attach --device-id=flutter-tester --debug-uri http://127.0.0.1:40409/k8IUol2dnPI=/
 ```
 
-#### How to use command line options in the Dart VM
+### How to use command line options in the Dart VM
 You can use the environment variables such as `FLUTTER_ENGINE_SWITCHES`, `FLUTTER_ENGINE_SWITCH_*` to use Dart VM command line options. If you want to fix always same observatory RUI, you can use the following command.
 
 ```Shell

--- a/DEBUGGING.md
+++ b/DEBUGGING.md
@@ -1,9 +1,18 @@
 # How to debug Flutter apps
-It is possible to do most things, including source-level debugging, profiling and hot reload when you debug Flutter apps on this embedder. Naturally, you need to use `libflutter_engine.so` built with debug mode.
+It is possible to do most things, including source-level debugging, profiling and hot reload when you debug Flutter apps on this embedder. Naturally, you need to **use `libflutter_engine.so` built with debug mode**.
+
+## Building with debug mode
+
+You need to build the embedder using `CMAKE_BUILD_TYPE` option.
+
+```Shell
+$ cmake -DUSER_PROJECT_PATH=examples/flutter-x11-client -DCMAKE_BUILD_TYPE=Debug ..
+$ cmake --build .
+```
 
 ## Getting the Observatory port
 
-You will find the following message in the console when you run Flutter apps. You need to attach a debugger to this port when you want to debug it. Note that the URI changes every time after launching.
+You will find the following message in the console when you run Flutter apps. You need to attach a debugger to this port when you want to debug it. **Note that the URI changes every time after launching**.
 
 ```Shell
 flutter: Observatory listening on http://127.0.0.1:40409/k8IUol2dnPI=/
@@ -12,15 +21,26 @@ flutter: Observatory listening on http://127.0.0.1:40409/k8IUol2dnPI=/
 
 ### Command line
 
-```Shell:
+```Shell
 $ flutter attach --device-id=flutter-tester --debug-uri http://127.0.0.1:40409/k8IUol2dnPI=/
+```
+
+#### How to use command line options in the Dart VM
+You can use the environment variables such as `FLUTTER_ENGINE_SWITCHES`, `FLUTTER_ENGINE_SWITCH_*` to use Dart VM command line options. If you want to fix always same observatory RUI, you can use the following command.
+
+```Shell
+$ FLUTTER_ENGINE_SWITCHES=2 \
+    FLUTTER_ENGINE_SWITCH_1="observatory-port=12345"  \
+    FLUTTER_ENGINE_SWITCH_2="disable-service-auth-codes" \
+    ./flutter-x11-clinet sample/build/linux/x64/debug/bundle
+flutter: Observatory listening on http://127.0.0.1:12345/
 ```
 
 ### VS Code
 
 Create a [launch.json file](https://code.visualstudio.com/docs/editor/debugging#_launch-configurations) like the following.
 
-```Json:
+```Json
 {
   "version": "0.2.0"
   "configurations": [

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ $ curl -O https://storage.googleapis.com/flutter_infra/flutter/FLUTTER_ENGINE/li
 Step 3) Install the library. Note that the downloaded library is only **debug mode** and for **x64** targets. 
 ```Shell
 $ unzip ./linux-x64-embedder
-$ sudo cp ./libflutter_engine.so /usr/lib
+$ sudo cp ./libflutter_engine.so <path_to_cmake_build_directory>
 ```
 
 ## 2. Examples

--- a/cmake/build.cmake
+++ b/cmake/build.cmake
@@ -62,6 +62,13 @@ if(USE_GLES3)
   add_definitions(-DUSE_GLES3)
 endif()
 
+# Flutter embedder runtime mode.
+if(NOT CMAKE_BUILD_TYPE MATCHES Debug)
+  add_definitions(
+    -DFLUTTER_RELEASE # release mode
+  )
+endif()
+
 # cmake script for developers.
 include(${USER_PROJECT_PATH}/cmake/user_build.cmake)
 

--- a/examples/flutter-drm-backend/cmake/user_build.cmake
+++ b/examples/flutter-drm-backend/cmake/user_build.cmake
@@ -1,10 +1,5 @@
 cmake_minimum_required(VERSION 3.10)
 
-# Flutter embedder runtime mode.
-add_definitions(
-  -DFLUTTER_RELEASE # release mode
-)
-
 # user binary name.
 set(TARGET flutter-drm-backend)
 

--- a/examples/flutter-external-texture-plugin/cmake/user_build.cmake
+++ b/examples/flutter-external-texture-plugin/cmake/user_build.cmake
@@ -1,10 +1,5 @@
 cmake_minimum_required(VERSION 3.10)
 
-# Flutter embedder runtime mode.
-add_definitions(
-  -DFLUTTER_RELEASE # release mode
-)
-
 # user binary name.
 set(TARGET flutter-client)
 

--- a/examples/flutter-wayland-client/cmake/user_build.cmake
+++ b/examples/flutter-wayland-client/cmake/user_build.cmake
@@ -1,10 +1,5 @@
 cmake_minimum_required(VERSION 3.10)
 
-# Flutter embedder runtime mode.
-add_definitions(
-  -DFLUTTER_RELEASE # release mode
-)
-
 # user binary name.
 set(TARGET flutter-client)
 

--- a/examples/flutter-weston-desktop-shell-virtual-keyboard/cmake/user_build.cmake
+++ b/examples/flutter-weston-desktop-shell-virtual-keyboard/cmake/user_build.cmake
@@ -1,10 +1,5 @@
 cmake_minimum_required(VERSION 3.10)
 
-# Flutter embedder runtime mode.
-add_definitions(
-  -DFLUTTER_RELEASE # release mode
-)
-
 # user binary name.
 set(TARGET flutter-desktop-shell)
 

--- a/examples/flutter-weston-desktop-shell/cmake/user_build.cmake
+++ b/examples/flutter-weston-desktop-shell/cmake/user_build.cmake
@@ -1,10 +1,5 @@
 cmake_minimum_required(VERSION 3.10)
 
-# Flutter embedder runtime mode.
-add_definitions(
-  -DFLUTTER_RELEASE # release mode
-)
-
 # user binary name.
 set(TARGET flutter-desktop-shell)
 

--- a/examples/flutter-x11-client/cmake/user_build.cmake
+++ b/examples/flutter-x11-client/cmake/user_build.cmake
@@ -1,10 +1,5 @@
 cmake_minimum_required(VERSION 3.10)
 
-# Flutter embedder runtime mode.
-add_definitions(
-  -DFLUTTER_RELEASE # release mode
-)
-
 # user binary name.
 set(TARGET flutter-x11-client)
 


### PR DESCRIPTION
I've changed that `FLUTTER_RELEASE` is changed in conjunction with `CMAKE_BUILD_TYPE`.

e.g.
```
$ cmake -DUSER_PROJECT_PATH=examples/flutter-x11-client -DCMAKE_BUILD_TYPE=Debug ..
$ cmake --build .
$ FLUTTER_ENGINE_SWITCHES=2 \
     FLUTTER_ENGINE_SWITCH_1="observatory-port=12345"  \
     FLUTTER_ENGINE_SWITCH_2="disable-service-auth-codes" \
     ./flutter-x11-clinet sample/build/linux/x64/debug/bundle
```

## Related issues
- https://github.com/sony/flutter-embedded-linux/issues/50