### PR TITLE
Refactoring: use unnamed namespace instead of static

### DIFF
--- a/src/flutter/shell/platform/linux_embedded/logger.cc
+++ b/src/flutter/shell/platform/linux_embedded/logger.cc
@@ -9,9 +9,9 @@ namespace flutter {
 namespace {
 
 #ifdef FLUTTER_RELEASE
-static constexpr int kFilterLogLevel = LINUXES_LOG_WARNING;
+constexpr int kFilterLogLevel = LINUXES_LOG_WARNING;
 #else
-static constexpr int kFilterLogLevel = LINUXES_LOG_TRACE;
+constexpr int kFilterLogLevel = LINUXES_LOG_TRACE;
 #endif
 
 const char* const kLogLevelNames[LINUXES_LOG_NUM] = {"TRACE", "INFO", "WARNING",

--- a/src/flutter/shell/platform/linux_embedded/plugin/key_event_plugin.cc
+++ b/src/flutter/shell/platform/linux_embedded/plugin/key_event_plugin.cc
@@ -20,24 +20,24 @@
 namespace flutter {
 
 namespace {
-static constexpr char kChannelName[] = "flutter/keyevent";
-static constexpr char kKeyCodeKey[] = "keyCode";
-static constexpr char kKeyMapKey[] = "keymap";
-static constexpr char kScanCodeKey[] = "scanCode";
-static constexpr char kModifiersKey[] = "modifiers";
-static constexpr char kTypeKey[] = "type";
-static constexpr char kToolkitKey[] = "toolkit";
-static constexpr char kUnicodeScalarValues[] = "unicodeScalarValues";
-static constexpr char kLinuxKeyMap[] = "linux";
-static constexpr char kGLFWKey[] = "glfw";
-static constexpr char kKeyUp[] = "keyup";
-static constexpr char kKeyDown[] = "keydown";
+constexpr char kChannelName[] = "flutter/keyevent";
+constexpr char kKeyCodeKey[] = "keyCode";
+constexpr char kKeyMapKey[] = "keymap";
+constexpr char kScanCodeKey[] = "scanCode";
+constexpr char kModifiersKey[] = "modifiers";
+constexpr char kTypeKey[] = "type";
+constexpr char kToolkitKey[] = "toolkit";
+constexpr char kUnicodeScalarValues[] = "unicodeScalarValues";
+constexpr char kLinuxKeyMap[] = "linux";
+constexpr char kGLFWKey[] = "glfw";
+constexpr char kKeyUp[] = "keyup";
+constexpr char kKeyDown[] = "keydown";
 
-static constexpr char kKeyboardConfigFile[] = "/etc/default/keyboard";
-static constexpr char kXkbmodelKey[] = "XKBMODEL";
-static constexpr char kXkblayoutKey[] = "XKBLAYOUT";
-static constexpr char kXkbvariantKey[] = "XKBVARIANT";
-static constexpr char kXkboptionsKey[] = "XKBOPTIONS";
+constexpr char kKeyboardConfigFile[] = "/etc/default/keyboard";
+constexpr char kXkbmodelKey[] = "XKBMODEL";
+constexpr char kXkblayoutKey[] = "XKBLAYOUT";
+constexpr char kXkbvariantKey[] = "XKBVARIANT";
+constexpr char kXkboptionsKey[] = "XKBOPTIONS";
 }  // namespace
 
 KeyeventPlugin::KeyeventPlugin(BinaryMessenger* messenger)
@@ -162,11 +162,11 @@ xkb_keymap* KeyeventPlugin::CreateKeymap(xkb_context* context) {
   if (map.find(kXkboptionsKey) != map.end()) {
     xkboptions = map[kXkboptionsKey];
   }
-  struct xkb_rule_names names = {.rules = NULL,
-                                 .model = xkbmodel.c_str(),
-                                 .layout = xkblayout.c_str(),
-                                 .variant = xkbvariant.c_str(),
-                                 .options = xkboptions.c_str()};
+  xkb_rule_names names = {.rules = NULL,
+                          .model = xkbmodel.c_str(),
+                          .layout = xkblayout.c_str(),
+                          .variant = xkbvariant.c_str(),
+                          .options = xkboptions.c_str()};
   return xkb_keymap_new_from_names(context, &names,
                                    XKB_KEYMAP_COMPILE_NO_FLAGS);
 }

--- a/src/flutter/shell/platform/linux_embedded/plugin/key_event_plugin_glfw_util.cc
+++ b/src/flutter/shell/platform/linux_embedded/plugin/key_event_plugin_glfw_util.cc
@@ -10,14 +10,16 @@
 
 #include "flutter/shell/platform/linux_embedded/logger.h"
 
-static constexpr uint32_t kXModifierShift = 0x0001;
-static constexpr uint32_t kXModifierCapsLock = 0x0002;
-static constexpr uint32_t kXModifierControl = 0x0004;
-static constexpr uint32_t kXModifierAlt = 0x0008;
-static constexpr uint32_t kXModifierNumLock = 0x0010;
-static constexpr uint32_t kXModifierSuper = 0x0040;
-
 namespace flutter {
+
+namespace {
+constexpr uint32_t kXModifierShift = 0x0001;
+constexpr uint32_t kXModifierCapsLock = 0x0002;
+constexpr uint32_t kXModifierControl = 0x0004;
+constexpr uint32_t kXModifierAlt = 0x0008;
+constexpr uint32_t kXModifierNumLock = 0x0010;
+constexpr uint32_t kXModifierSuper = 0x0040;
+}  // namespace
 
 uint32_t GetGlfwModifiers(xkb_mod_mask_t xkb_mod_mask) {
   uint32_t mods = 0;

--- a/src/flutter/shell/platform/linux_embedded/plugin/mouse_cursor_plugin.cc
+++ b/src/flutter/shell/platform/linux_embedded/plugin/mouse_cursor_plugin.cc
@@ -20,11 +20,13 @@
 
 namespace flutter {
 
-static constexpr char kChannelName[] = "flutter/mousecursor";
+namespace {
+constexpr char kChannelName[] = "flutter/mousecursor";
 
-static constexpr char kActivateSystemCursorMethod[] = "activateSystemCursor";
+constexpr char kActivateSystemCursorMethod[] = "activateSystemCursor";
 
-static constexpr char kKindKey[] = "kind";
+constexpr char kKindKey[] = "kind";
+}  // namespace
 
 MouseCursorPlugin::MouseCursorPlugin(BinaryMessenger* messenger,
                                      WindowBindingHandler* delegate)

--- a/src/flutter/shell/platform/linux_embedded/plugin/platform_plugin.cc
+++ b/src/flutter/shell/platform/linux_embedded/plugin/platform_plugin.cc
@@ -20,17 +20,19 @@
 
 namespace flutter {
 
-static constexpr char kChannelName[] = "flutter/platform";
+namespace {
+constexpr char kChannelName[] = "flutter/platform";
 
-static constexpr char kGetClipboardDataMethod[] = "Clipboard.getData";
-static constexpr char kSetClipboardDataMethod[] = "Clipboard.setData";
-static constexpr char kSystemNavigatorPopMethod[] = "SystemNavigator.pop";
+constexpr char kGetClipboardDataMethod[] = "Clipboard.getData";
+constexpr char kSetClipboardDataMethod[] = "Clipboard.setData";
+constexpr char kSystemNavigatorPopMethod[] = "SystemNavigator.pop";
 
-static constexpr char kTextPlainFormat[] = "text/plain";
-static constexpr char kTextKey[] = "text";
+constexpr char kTextPlainFormat[] = "text/plain";
+constexpr char kTextKey[] = "text";
 
-static constexpr char kUnknownClipboardFormatError[] =
+constexpr char kUnknownClipboardFormatError[] =
     "Unknown clipboard format error";
+}  // namespace
 
 PlatformPlugin::PlatformPlugin(BinaryMessenger* messenger,
                                WindowBindingHandler* delegate)

--- a/src/flutter/shell/platform/linux_embedded/plugin/text_input_plugin.cc
+++ b/src/flutter/shell/platform/linux_embedded/plugin/text_input_plugin.cc
@@ -24,35 +24,36 @@
 
 namespace flutter {
 
-static constexpr char kChannelName[] = "flutter/textinput";
+namespace {
+constexpr char kChannelName[] = "flutter/textinput";
 
-static constexpr char kSetEditingStateMethod[] = "TextInput.setEditingState";
-static constexpr char kClearClientMethod[] = "TextInput.clearClient";
-static constexpr char kSetClientMethod[] = "TextInput.setClient";
-static constexpr char kShowMethod[] = "TextInput.show";
-static constexpr char kHideMethod[] = "TextInput.hide";
+constexpr char kSetEditingStateMethod[] = "TextInput.setEditingState";
+constexpr char kClearClientMethod[] = "TextInput.clearClient";
+constexpr char kSetClientMethod[] = "TextInput.setClient";
+constexpr char kShowMethod[] = "TextInput.show";
+constexpr char kHideMethod[] = "TextInput.hide";
 
-static constexpr char kMultilineInputType[] = "TextInputType.multiline";
+constexpr char kMultilineInputType[] = "TextInputType.multiline";
 
-static constexpr char kUpdateEditingStateMethod[] =
+constexpr char kUpdateEditingStateMethod[] =
     "TextInputClient.updateEditingState";
-static constexpr char kPerformActionMethod[] = "TextInputClient.performAction";
+constexpr char kPerformActionMethod[] = "TextInputClient.performAction";
 
-static constexpr char kTextInputAction[] = "inputAction";
-static constexpr char kTextInputType[] = "inputType";
-static constexpr char kTextInputTypeName[] = "name";
-static constexpr char kComposingBaseKey[] = "composingBase";
-static constexpr char kComposingExtentKey[] = "composingExtent";
-static constexpr char kSelectionAffinityKey[] = "selectionAffinity";
-static constexpr char kAffinityDownstream[] = "TextAffinity.downstream";
-static constexpr char kSelectionBaseKey[] = "selectionBase";
-static constexpr char kSelectionExtentKey[] = "selectionExtent";
-static constexpr char kSelectionIsDirectionalKey[] = "selectionIsDirectional";
-static constexpr char kTextKey[] = "text";
+constexpr char kTextInputAction[] = "inputAction";
+constexpr char kTextInputType[] = "inputType";
+constexpr char kTextInputTypeName[] = "name";
+constexpr char kComposingBaseKey[] = "composingBase";
+constexpr char kComposingExtentKey[] = "composingExtent";
+constexpr char kSelectionAffinityKey[] = "selectionAffinity";
+constexpr char kAffinityDownstream[] = "TextAffinity.downstream";
+constexpr char kSelectionBaseKey[] = "selectionBase";
+constexpr char kSelectionExtentKey[] = "selectionExtent";
+constexpr char kSelectionIsDirectionalKey[] = "selectionIsDirectional";
+constexpr char kTextKey[] = "text";
 
-static constexpr char kBadArgumentError[] = "Bad Arguments";
-static constexpr char kInternalConsistencyError[] =
-    "Internal Consistency Error";
+constexpr char kBadArgumentError[] = "Bad Arguments";
+constexpr char kInternalConsistencyError[] = "Internal Consistency Error";
+}  // namespace
 
 void TextInputPlugin::OnKeyPressed(uint32_t keycode, uint32_t code_point) {
   if (!active_model_) {


### PR DESCRIPTION
I refactored some files to use unnamed namespace instead of static except for the code files around window/surface which are working on currently.