### PR TITLE
Initialize binding_handler_delegate_ to null

### DIFF
--- a/src/flutter/shell/platform/linux_embedded/window/linuxes_window_drm.h
+++ b/src/flutter/shell/platform/linux_embedded/window/linuxes_window_drm.h
@@ -463,7 +463,7 @@ class LinuxesWindowDrm : public LinuxesWindow, public WindowBindingHandler {
 
   // A pointer to a FlutterWindowsView that can be used to update engine
   // windowing and input state.
-  WindowBindingHandlerDelegate* binding_handler_delegate_;
+  WindowBindingHandlerDelegate* binding_handler_delegate_ = nullptr;
 
   std::unique_ptr<T> native_window_;
   std::unique_ptr<SurfaceGl> render_surface_;

--- a/src/flutter/shell/platform/linux_embedded/window/linuxes_window_wayland.h
+++ b/src/flutter/shell/platform/linux_embedded/window/linuxes_window_wayland.h
@@ -97,7 +97,7 @@ class LinuxesWindowWayland : public LinuxesWindow, public WindowBindingHandler {
 
   // A pointer to a FlutterWindowsView that can be used to update engine
   // windowing and input state.
-  WindowBindingHandlerDelegate* binding_handler_delegate_;
+  WindowBindingHandlerDelegate* binding_handler_delegate_ = nullptr;
 
   std::unique_ptr<NativeWindowWayland> native_window_;
   std::unique_ptr<SurfaceGl> render_surface_;

--- a/src/flutter/shell/platform/linux_embedded/window/linuxes_window_x11.h
+++ b/src/flutter/shell/platform/linux_embedded/window/linuxes_window_x11.h
@@ -63,7 +63,7 @@ class LinuxesWindowX11 : public LinuxesWindow, public WindowBindingHandler {
 
   // A pointer to a FlutterWindowsView that can be used to update engine
   // windowing and input state.
-  WindowBindingHandlerDelegate* binding_handler_delegate_;
+  WindowBindingHandlerDelegate* binding_handler_delegate_ = nullptr;
 
   Display* display_ = nullptr;
   std::unique_ptr<NativeWindowX11> native_window_;


### PR DESCRIPTION
`binding_handler_delegate_` isn't initialized to null. If a window event happens before setting `binding_handler_delegate_`, the embedder will crash.