### PR TITLE
Refactoring: delete FLUTTER_LINUXES_BUTTON_* defines

### DIFF
--- a/src/flutter/shell/platform/linux_embedded/flutter_linuxes_view.cc
+++ b/src/flutter/shell/platform/linux_embedded/flutter_linuxes_view.cc
@@ -171,7 +171,7 @@ void FlutterLinuxesView::OnKeyMap(uint32_t format, int fd, uint32_t size) {
 }
 
 void FlutterLinuxesView::OnKey(uint32_t key, bool pressed) {
-  keyboard_handler_->OnKey(key, state);
+  keyboard_handler_->OnKey(key, pressed);
   if (pressed) {
     auto code_point = keyboard_handler_->GetCodePoint(key);
     if (!keyboard_handler_->IsTextInputSuppressed(code_point)) {

--- a/src/flutter/shell/platform/linux_embedded/flutter_linuxes_view.cc
+++ b/src/flutter/shell/platform/linux_embedded/flutter_linuxes_view.cc
@@ -170,9 +170,9 @@ void FlutterLinuxesView::OnKeyMap(uint32_t format, int fd, uint32_t size) {
   keyboard_handler_->OnKeymap(format, fd, size);
 }
 
-void FlutterLinuxesView::OnKey(uint32_t key, uint32_t state) {
+void FlutterLinuxesView::OnKey(uint32_t key, bool pressed) {
   keyboard_handler_->OnKey(key, state);
-  if (state == FLUTTER_LINUXES_BUTTON_DOWN) {
+  if (pressed) {
     auto code_point = keyboard_handler_->GetCodePoint(key);
     if (!keyboard_handler_->IsTextInputSuppressed(code_point)) {
       textinput_handler_->OnKeyPressed(key, code_point);

--- a/src/flutter/shell/platform/linux_embedded/flutter_linuxes_view.h
+++ b/src/flutter/shell/platform/linux_embedded/flutter_linuxes_view.h
@@ -103,7 +103,7 @@ class FlutterLinuxesView : public WindowBindingHandlerDelegate {
                       uint32_t mods_locked, uint32_t group) override;
 
   // |WindowBindingHandlerDelegate|
-  void OnKey(uint32_t key, uint32_t state) override;
+  void OnKey(uint32_t key, bool pressed) override;
 
   // |WindowBindingHandlerDelegate|
   void OnVirtualKey(uint32_t code_point) override;

--- a/src/flutter/shell/platform/linux_embedded/plugin/key_event_plugin.cc
+++ b/src/flutter/shell/platform/linux_embedded/plugin/key_event_plugin.cc
@@ -126,7 +126,11 @@ void KeyeventPlugin::SendKeyEvent(uint32_t keycode, uint32_t unicode,
   if (unicode != 0) {
     event.AddMember(kUnicodeScalarValues, unicode, allocator);
   }
-  event.AddMember(kTypeKey, pressed ? kKeyDown : kKeyUp, allocator);
+  if (pressed) {
+    event.AddMember(kTypeKey, kKeyDown, allocator);
+  } else {
+    event.AddMember(kTypeKey, kKeyUp, allocator);
+  }
   channel_->Send(event);
 }
 

--- a/src/flutter/shell/platform/linux_embedded/plugin/key_event_plugin.cc
+++ b/src/flutter/shell/platform/linux_embedded/plugin/key_event_plugin.cc
@@ -94,16 +94,16 @@ bool KeyeventPlugin::IsTextInputSuppressed(uint32_t code_point) {
   return false;
 }
 
-void KeyeventPlugin::OnKey(uint32_t keycode, uint32_t state) {
+void KeyeventPlugin::OnKey(uint32_t keycode, bool pressed) {
 #if !defined(DISPLAY_BACKEND_TYPE_WAYLAND)
   // We cannot get notifications of modifier keys when we use the DRM/X11
   // backends. In this case, we need to handle it by using xkb_state_update_key.
-  OnModifiers(keycode, state);
+  OnModifiers(keycode, pressed);
 #endif
   auto unicode = GetCodePoint(keycode);
   auto mods = GetGlfwModifiers(xkb_keymap_, xkb_mods_mask_);
   auto keyscancode = GetGlfwKeycode(keycode);
-  SendKeyEvent(keyscancode, unicode, mods, state);
+  SendKeyEvent(keyscancode, unicode, mods, pressed);
 }
 
 void KeyeventPlugin::OnModifiers(uint32_t mods_depressed, uint32_t mods_latched,
@@ -115,7 +115,7 @@ void KeyeventPlugin::OnModifiers(uint32_t mods_depressed, uint32_t mods_latched,
 }
 
 void KeyeventPlugin::SendKeyEvent(uint32_t keycode, uint32_t unicode,
-                                  uint32_t modifiers, uint32_t key_state) {
+                                  uint32_t modifiers, bool pressed) {
   rapidjson::Document event(rapidjson::kObjectType);
   auto& allocator = event.GetAllocator();
   event.AddMember(kKeyCodeKey, keycode, allocator);
@@ -126,23 +126,13 @@ void KeyeventPlugin::SendKeyEvent(uint32_t keycode, uint32_t unicode,
   if (unicode != 0) {
     event.AddMember(kUnicodeScalarValues, unicode, allocator);
   }
-  switch (key_state) {
-    case FLUTTER_LINUXES_BUTTON_DOWN:
-      event.AddMember(kTypeKey, kKeyDown, allocator);
-      break;
-    case FLUTTER_LINUXES_BUTTON_UP:
-      event.AddMember(kTypeKey, kKeyUp, allocator);
-      break;
-    default:
-      LINUXES_LOG(ERROR) << "Unknown key event action: " << key_state;
-      return;
-  }
+  event.AddMember(kTypeKey, pressed ? kKeyDown : kKeyUp, allocator);
   channel_->Send(event);
 }
 
-void KeyeventPlugin::OnModifiers(uint32_t keycode, uint32_t state) {
+void KeyeventPlugin::OnModifiers(uint32_t keycode, bool pressed) {
   xkb_state_update_key(xkb_state_, keycode + 8,
-                       static_cast<xkb_key_direction>(state));
+                       pressed ? XKB_KEY_DOWN : XKB_KEY_UP);
   xkb_mods_mask_ =
       xkb_state_serialize_mods(xkb_state_, XKB_STATE_MODS_EFFECTIVE);
 }

--- a/src/flutter/shell/platform/linux_embedded/plugin/key_event_plugin.h
+++ b/src/flutter/shell/platform/linux_embedded/plugin/key_event_plugin.h
@@ -23,7 +23,7 @@ class KeyeventPlugin {
 
   void OnKeymap(uint32_t format, uint32_t fd, uint32_t size);
 
-  void OnKey(uint32_t keycode, uint32_t state);
+  void OnKey(uint32_t keycode, bool pressed);
 
   void OnModifiers(uint32_t mods_depressed, uint32_t mods_latched,
                    uint32_t mods_locked, uint32_t group);
@@ -34,8 +34,8 @@ class KeyeventPlugin {
 
  private:
   void SendKeyEvent(uint32_t keycode, uint32_t unicode, uint32_t modifiers,
-                    uint32_t key_state);
-  void OnModifiers(uint32_t keycode, uint32_t state);
+                    bool pressed);
+  void OnModifiers(uint32_t keycode, bool pressed);
   xkb_keymap* CreateKeymap(xkb_context* context);
   std::unordered_map<std::string, std::string> GetKeyboardConfig(
       std::string filename);

--- a/src/flutter/shell/platform/linux_embedded/window/linuxes_window_drm.h
+++ b/src/flutter/shell/platform/linux_embedded/window/linuxes_window_drm.h
@@ -294,9 +294,7 @@ class LinuxesWindowDrm : public LinuxesWindow, public WindowBindingHandler {
           static_cast<uint16_t>(libinput_event_keyboard_get_key(key_event));
       auto key_state = libinput_event_keyboard_get_key_state(key_event);
       binding_handler_delegate_->OnKey(evdev_keycode,
-                                       (key_state == LIBINPUT_KEY_STATE_PRESSED)
-                                           ? FLUTTER_LINUXES_BUTTON_DOWN
-                                           : FLUTTER_LINUXES_BUTTON_UP);
+                                       key_state == LIBINPUT_KEY_STATE_PRESSED);
     }
   }
 

--- a/src/flutter/shell/platform/linux_embedded/window/linuxes_window_wayland.cc
+++ b/src/flutter/shell/platform/linux_embedded/window/linuxes_window_wayland.cc
@@ -250,9 +250,7 @@ const wl_keyboard_listener LinuxesWindowWayland::kWlKeyboardListener = {
       self->serial_ = serial;
       if (self->binding_handler_delegate_) {
         self->binding_handler_delegate_->OnKey(
-            key, (state == WL_KEYBOARD_KEY_STATE_PRESSED)
-                     ? FLUTTER_LINUXES_BUTTON_DOWN
-                     : FLUTTER_LINUXES_BUTTON_UP);
+            key, state == WL_KEYBOARD_KEY_STATE_PRESSED);
       }
     },
     .modifiers = [](void* data, wl_keyboard* wl_keyboard, uint32_t serial,

--- a/src/flutter/shell/platform/linux_embedded/window/linuxes_window_x11.cc
+++ b/src/flutter/shell/platform/linux_embedded/window/linuxes_window_x11.cc
@@ -74,14 +74,14 @@ bool LinuxesWindowX11::DispatchEvent() {
       } break;
       case KeyPress:
         if (binding_handler_delegate_) {
-          binding_handler_delegate_->OnKey(event.xkey.keycode - 8,
-                                           FLUTTER_LINUXES_BUTTON_DOWN);
+          constexpr bool pressed = true;
+          binding_handler_delegate_->OnKey(event.xkey.keycode - 8, pressed);
         }
         break;
       case KeyRelease:
         if (binding_handler_delegate_) {
-          binding_handler_delegate_->OnKey(event.xkey.keycode - 8,
-                                           FLUTTER_LINUXES_BUTTON_UP);
+          constexpr bool pressed = false;
+          binding_handler_delegate_->OnKey(event.xkey.keycode - 8, pressed);
         }
         break;
       case ConfigureNotify: {

--- a/src/flutter/shell/platform/linux_embedded/window_binding_handler_delegate.h
+++ b/src/flutter/shell/platform/linux_embedded/window_binding_handler_delegate.h
@@ -7,9 +7,6 @@
 
 #include "flutter/shell/platform/embedder/embedder.h"
 
-#define FLUTTER_LINUXES_BUTTON_UP 0
-#define FLUTTER_LINUXES_BUTTON_DOWN 1
-
 namespace flutter {
 
 class WindowBindingHandlerDelegate {
@@ -63,7 +60,7 @@ class WindowBindingHandlerDelegate {
 
   // Notifies delegate that backing window key has been pressed.
   // Typically called by currently configured WindowBindingHandler
-  virtual void OnKey(uint32_t key, uint32_t state) = 0;
+  virtual void OnKey(uint32_t key, bool pressed) = 0;
 
   // Notifies delegate that backing window virtual key has been pressed.
   // Typically called by currently configured WindowBindingHandler


### PR DESCRIPTION
I deleted FLUTTER_LINUXES_BUTTON_DOWN and FLUTTER_LINUXES_BUTTON_UP defines, and replaced these into simple bool var.