### PR TITLE
Support text input protocol v3 for onscreen keyboards on Wayland

### DIFF
--- a/cmake/build.cmake
+++ b/cmake/build.cmake
@@ -48,10 +48,16 @@ else()
     CODE_FILE ${_wayland_protocols_src_dir}/text-input-unstable-v1-protocol.c
     HEADER_FILE ${_wayland_protocols_src_dir}/text-input-unstable-v1-client-protocol.h)
 
+  generate_wayland_client_protocol(
+    PROTOCOL_FILE ${_wayland_protocols_xml_dir}/unstable/text-input/text-input-unstable-v3.xml
+    CODE_FILE ${_wayland_protocols_src_dir}/text-input-unstable-v3-protocol.c
+    HEADER_FILE ${_wayland_protocols_src_dir}/text-input-unstable-v3-client-protocol.h)
+
   add_definitions(-DDISPLAY_BACKEND_TYPE_WAYLAND)
   set(DISPLAY_BACKEND_SRC
     ${_wayland_protocols_src_dir}/xdg-shell-protocol.c
     ${_wayland_protocols_src_dir}/text-input-unstable-v1-protocol.c
+    ${_wayland_protocols_src_dir}/text-input-unstable-v3-protocol.c
     src/flutter/shell/platform/linux_embedded/window/linuxes_window_wayland.cc
     src/flutter/shell/platform/linux_embedded/window/native_window_wayland.cc)
 endif()

--- a/src/flutter/shell/platform/linux_embedded/window/linuxes_window_wayland.cc
+++ b/src/flutter/shell/platform/linux_embedded/window/linuxes_window_wayland.cc
@@ -425,7 +425,6 @@ const zwp_text_input_v3_listener LinuxesWindowWayland::kZwpTextInputV3Listener =
                uint32_t before_length, uint32_t after_length) -> void {},
         .done = [](void* data, zwp_text_input_v3* zwp_text_input_v3,
                    uint32_t serial) -> void {},
-
 };
 
 const wl_data_device_listener LinuxesWindowWayland::kWlDataDeviceListener = {

--- a/src/flutter/shell/platform/linux_embedded/window/linuxes_window_wayland.cc
+++ b/src/flutter/shell/platform/linux_embedded/window/linuxes_window_wayland.cc
@@ -790,7 +790,7 @@ void LinuxesWindowWayland::UpdateVirtualKeyboardStatus(const bool show) {
       zwp_text_input_v3_commit(zwp_text_input_v3_);
 
       zwp_text_input_v3_set_content_type(
-          zwp_text_input_, ZWP_TEXT_INPUT_V3_CONTENT_HINT_NONE,
+          zwp_text_input_v3_, ZWP_TEXT_INPUT_V3_CONTENT_HINT_NONE,
           ZWP_TEXT_INPUT_V3_CONTENT_PURPOSE_TERMINAL);
       zwp_text_input_v3_commit(zwp_text_input_v3_);
     } else {

--- a/src/flutter/shell/platform/linux_embedded/window/linuxes_window_wayland.h
+++ b/src/flutter/shell/platform/linux_embedded/window/linuxes_window_wayland.h
@@ -21,6 +21,7 @@
 // wayland-scanner.
 extern "C" {
 #include "wayland/protocol/text-input-unstable-v1-client-protocol.h"
+#include "wayland/protocol/text-input-unstable-v3-client-protocol.h"
 #include "wayland/protocol/weston-desktop-shell-client-protocol.h"
 #include "wayland/protocol/xdg-shell-client-protocol.h"
 }
@@ -93,9 +94,10 @@ class LinuxesWindowWayland : public LinuxesWindow, public WindowBindingHandler {
   static const wl_touch_listener kWlTouchListener;
   static const wl_keyboard_listener kWlKeyboardListener;
   static const wl_output_listener kWlOutputListener;
-  static const zwp_text_input_v1_listener kZwpTextInputV1Listener;
   static const wl_data_device_listener kWlDataDeviceListener;
   static const wl_data_source_listener kWlDataSourceListener;
+  static const zwp_text_input_v1_listener kZwpTextInputV1Listener;
+  static const zwp_text_input_v3_listener kZwpTextInputV3Listener;
 
   // A pointer to a FlutterWindowsView that can be used to update engine
   // windowing and input state.
@@ -109,9 +111,6 @@ class LinuxesWindowWayland : public LinuxesWindow, public WindowBindingHandler {
   wl_display* wl_display_;
   wl_registry* wl_registry_;
   wl_compositor* wl_compositor_;
-  xdg_wm_base* xdg_wm_base_;
-  xdg_surface* xdg_surface_;
-  xdg_toplevel* xdg_toplevel_;
   wl_seat* wl_seat_;
   wl_output* wl_output_;
   wl_shm* wl_shm_;
@@ -120,8 +119,15 @@ class LinuxesWindowWayland : public LinuxesWindow, public WindowBindingHandler {
   wl_keyboard* wl_keyboard_;
   wl_surface* wl_cursor_surface_;
   wl_cursor_theme* wl_cursor_theme_;
+  xdg_wm_base* xdg_wm_base_;
+  xdg_surface* xdg_surface_;
+  xdg_toplevel* xdg_toplevel_;
+
+  // text-input protocol for onscreen keyboard inputs.
   zwp_text_input_manager_v1* zwp_text_input_manager_v1_;
+  zwp_text_input_manager_v3* zwp_text_input_manager_v3_;
   zwp_text_input_v1* zwp_text_input_v1_;
+  zwp_text_input_v3* zwp_text_input_v3_;
 
   CursorInfo cursor_info_;
 


### PR DESCRIPTION
I added text-input-protocol-v3 for onscreen keyboards on Wayland compositors. Currently, Weston doesn't still support v3. On the other hand, other compositors have switched from v1 to v2 or v3. I think we need to support both of them now.

## Related issues
- https://github.com/sony/flutter-embedded-linux/issues/108

## Links
- https://gitlab.freedesktop.org/wayland/weston/-/merge_requests/150