### PR TITLE
Fixed bug regarding the display of Wayland's on-screen keyboard

### DIFF
--- a/src/flutter/shell/platform/linux_embedded/window/linuxes_window_wayland.cc
+++ b/src/flutter/shell/platform/linux_embedded/window/linuxes_window_wayland.cc
@@ -1070,7 +1070,6 @@ void LinuxesWindowWayland::ShowVirtualKeyboard() {
     }
   }
 }
-}
 
 void LinuxesWindowWayland::DismissVirtualKeybaord() {
   if (zwp_text_input_v3_) {

--- a/src/flutter/shell/platform/linux_embedded/window/linuxes_window_wayland.h
+++ b/src/flutter/shell/platform/linux_embedded/window/linuxes_window_wayland.h
@@ -86,6 +86,10 @@ class LinuxesWindowWayland : public LinuxesWindow, public WindowBindingHandler {
 
   wl_cursor* GetWlCursor(const std::string& cursor_name);
 
+  void ShowVirtualKeyboard();
+
+  void DismissVirtualKeybaord();
+
   static const wl_registry_listener kWlRegistryListener;
   static const xdg_wm_base_listener kXdgWmBaseListener;
   static const xdg_surface_listener kXdgSurfaceListener;
@@ -107,6 +111,9 @@ class LinuxesWindowWayland : public LinuxesWindow, public WindowBindingHandler {
   std::unique_ptr<SurfaceGl> render_surface_;
 
   bool display_valid_;
+
+  // Indicates that exists a keyboard show request from Flutter Engine.
+  bool is_requested_show_virtual_keyboard_;
 
   wl_display* wl_display_;
   wl_registry* wl_registry_;


### PR DESCRIPTION
I fixed the following bug.

See: https://github.com/sony/flutter-embedded-linux/issues/108#issuecomment-845544970
> Some additional observations:
If the user switches from the Flutter Wayland application with the onscreen keyboard opened, the keyboard will behave as expected (close or remain opened).
However when the user returns back to the Flutter app, the text field appears to have the focus (cursor is blinking) but the onscreen keyboard will be closed.
To bring the onscreen keyboard again - lose focus from the input field and tap on it again or focus on a different input field.