### PR TITLE
Update .gclient file to not download other than Linux deps

### DIFF
--- a/doc/building-engine-embedder.md
+++ b/doc/building-engine-embedder.md
@@ -35,6 +35,10 @@ solutions = [
     "custom_deps": {},
     "deps_file": "DEPS",
     "safesync_url": "",
+    "custom_vars" : {
+      "download_android_deps" : False,
+      "download_windows_deps" : False,
+    },
   },
 ]
 ```
@@ -58,6 +62,10 @@ solutions = [
     "custom_deps": {},
     "deps_file": "DEPS",
     "safesync_url": "",
+    "custom_vars" : {
+      "download_android_deps" : False,
+      "download_windows_deps" : False,
+    },
   },
 ]
 ```

--- a/doc/building-engine-embedder.md
+++ b/doc/building-engine-embedder.md
@@ -35,9 +35,9 @@ solutions = [
     "custom_deps": {},
     "deps_file": "DEPS",
     "safesync_url": "",
-    "custom_vars" : {
-      "download_android_deps" : False,
-      "download_windows_deps" : False,
+    "custom_vars": {
+      "download_android_deps": False,
+      "download_windows_deps": False,
     },
   },
 ]
@@ -62,9 +62,9 @@ solutions = [
     "custom_deps": {},
     "deps_file": "DEPS",
     "safesync_url": "",
-    "custom_vars" : {
-      "download_android_deps" : False,
-      "download_windows_deps" : False,
+    "custom_vars": {
+      "download_android_deps": False,
+      "download_windows_deps": False,
     },
   },
 ]

--- a/meta-flutter/recipes-graphics/flutter-engine/flutter-engine.bb
+++ b/meta-flutter/recipes-graphics/flutter-engine/flutter-engine.bb
@@ -45,9 +45,9 @@ do_configure() {
             "custom_deps": {},
             "deps_file": "DEPS",
             "safesync_url": "",
-            "custom_vars" : {
-                "download_android_deps" : False,
-                "download_windows_deps" : False,
+            "custom_vars": {
+                "download_android_deps": False,
+                "download_windows_deps": False,
             },
         },
     ]' > .gclient

--- a/meta-flutter/recipes-graphics/flutter-engine/flutter-engine.bb
+++ b/meta-flutter/recipes-graphics/flutter-engine/flutter-engine.bb
@@ -45,6 +45,10 @@ do_configure() {
             "custom_deps": {},
             "deps_file": "DEPS",
             "safesync_url": "",
+            "custom_vars" : {
+                "download_android_deps" : False,
+                "download_windows_deps" : False,
+            },
         },
     ]' > .gclient
     gclient sync


### PR DESCRIPTION
I updated `.gclinet` file to not download other than Linux dependent libraries. This change helps speed up build tasks of Flutter Engine.