### PR TITLE
Add platform views plugin as a first implementation

### DIFF
--- a/cmake/build.cmake
+++ b/cmake/build.cmake
@@ -119,6 +119,7 @@ add_executable(${TARGET}
   src/flutter/shell/platform/linux_embedded/plugins/mouse_cursor_plugin.cc
   src/flutter/shell/platform/linux_embedded/plugins/navigation_plugin.cc
   src/flutter/shell/platform/linux_embedded/plugins/platform_plugin.cc
+  src/flutter/shell/platform/linux_embedded/plugins/platform_views_plugin.cc
   src/flutter/shell/platform/linux_embedded/plugins/text_input_plugin.cc
   src/flutter/shell/platform/linux_embedded/surface/context_egl.cc
   src/flutter/shell/platform/linux_embedded/surface/egl_utils.cc

--- a/src/flutter/shell/platform/linux_embedded/flutter_linuxes.cc
+++ b/src/flutter/shell/platform/linux_embedded/flutter_linuxes.cc
@@ -11,7 +11,6 @@
 
 #include "flutter/shell/platform/common/client_wrapper/include/flutter/plugin_registrar.h"
 #include "flutter/shell/platform/common/incoming_message_dispatcher.h"
-#include "flutter/shell/platform/embedder/embedder.h"
 #include "flutter/shell/platform/linux_embedded/flutter_linuxes_engine.h"
 #include "flutter/shell/platform/linux_embedded/flutter_linuxes_state.h"
 #include "flutter/shell/platform/linux_embedded/flutter_linuxes_view.h"

--- a/src/flutter/shell/platform/linux_embedded/flutter_linuxes.cc
+++ b/src/flutter/shell/platform/linux_embedded/flutter_linuxes.cc
@@ -258,3 +258,10 @@ bool FlutterDesktopTextureRegistrarMarkExternalTextureFrameAvailable(
   return TextureRegistrarFromHandle(texture_registrar)
       ->MarkTextureFrameAvailable(texture_id);
 }
+
+void FlutterDesktopRegisterPlatformViewFactory(
+    FlutterDesktopPluginRegistrarRef registrar, const char* view_type,
+    std::unique_ptr<FlutterDesktopPlatformViewFactory> view_factory) {
+  registrar->engine->view()->RegisterPlatformViewFactory(
+      view_type, std::move(view_factory));
+}

--- a/src/flutter/shell/platform/linux_embedded/flutter_linuxes_view.cc
+++ b/src/flutter/shell/platform/linux_embedded/flutter_linuxes_view.cc
@@ -52,6 +52,8 @@ void FlutterLinuxesView::SetEngine(
       std::make_unique<flutter::LifecyclePlugin>(internal_plugin_messenger);
   navigation_handler_ =
       std::make_unique<flutter::NavigationPlugin>(internal_plugin_messenger);
+  platform_views_handler_ =
+      std::make_unique<flutter::PlatformViewsPlugin>(internal_plugin_messenger);
 
   PhysicalWindowBounds bounds = binding_handler_->GetPhysicalWindowBounds();
   SendWindowMetrics(bounds.width, bounds.height,

--- a/src/flutter/shell/platform/linux_embedded/flutter_linuxes_view.cc
+++ b/src/flutter/shell/platform/linux_embedded/flutter_linuxes_view.cc
@@ -60,6 +60,12 @@ void FlutterLinuxesView::SetEngine(
                     binding_handler_->GetDpiScale());
 }
 
+void FlutterLinuxesView::RegisterPlatformViewFactory(
+    const char* view_type,
+    std::unique_ptr<FlutterDesktopPlatformViewFactory> factory) {
+  platform_views_handler_->RegisterViewFactory(view_type, std::move(factory));
+}
+
 void FlutterLinuxesView::OnWindowSizeChanged(size_t width,
                                              size_t height) const {
   if (!GetRenderSurfaceTarget()->OnScreenSurfaceResize(width, height)) {

--- a/src/flutter/shell/platform/linux_embedded/flutter_linuxes_view.h
+++ b/src/flutter/shell/platform/linux_embedded/flutter_linuxes_view.h
@@ -21,6 +21,7 @@
 #include "flutter/shell/platform/linux_embedded/plugins/platform_views_plugin.h"
 #include "flutter/shell/platform/linux_embedded/plugins/text_input_plugin.h"
 #include "flutter/shell/platform/linux_embedded/public/flutter_linuxes.h"
+#include "flutter/shell/platform/linux_embedded/public/flutter_platform_views.h"
 #include "flutter/shell/platform/linux_embedded/window_binding_handler.h"
 #include "flutter/shell/platform/linux_embedded/window_binding_handler_delegate.h"
 
@@ -44,6 +45,11 @@ class FlutterLinuxesView : public WindowBindingHandlerDelegate {
   // Configures the window instance with an instance of a running Flutter
   // engine.
   void SetEngine(std::unique_ptr<FlutterLinuxesEngine> engine);
+
+  // Registers a factory of the platform view.
+  void RegisterPlatformViewFactory(
+      const char* view_type,
+      std::unique_ptr<FlutterDesktopPlatformViewFactory> factory);
 
   // Creates rendering surface for Flutter engine to draw into.
   // Should be called before calling FlutterEngineRun using this view.

--- a/src/flutter/shell/platform/linux_embedded/flutter_linuxes_view.h
+++ b/src/flutter/shell/platform/linux_embedded/flutter_linuxes_view.h
@@ -18,6 +18,7 @@
 #include "flutter/shell/platform/linux_embedded/plugins/mouse_cursor_plugin.h"
 #include "flutter/shell/platform/linux_embedded/plugins/navigation_plugin.h"
 #include "flutter/shell/platform/linux_embedded/plugins/platform_plugin.h"
+#include "flutter/shell/platform/linux_embedded/plugins/platform_views_plugin.h"
 #include "flutter/shell/platform/linux_embedded/plugins/text_input_plugin.h"
 #include "flutter/shell/platform/linux_embedded/public/flutter_linuxes.h"
 #include "flutter/shell/platform/linux_embedded/window_binding_handler.h"
@@ -244,6 +245,9 @@ class FlutterLinuxesView : public WindowBindingHandlerDelegate {
 
   // Handler for flutter/navigation channel.
   std::unique_ptr<flutter::NavigationPlugin> navigation_handler_;
+
+  // Handler for flutter/platform_views channel.
+  std::unique_ptr<flutter::PlatformViewsPlugin> platform_views_handler_;
 
   // Currently configured WindowBindingHandler for view.
   std::unique_ptr<flutter::WindowBindingHandler> binding_handler_;

--- a/src/flutter/shell/platform/linux_embedded/plugins/platform_views_plugin.cc
+++ b/src/flutter/shell/platform/linux_embedded/plugins/platform_views_plugin.cc
@@ -1,0 +1,57 @@
+// Copyright 2021 Sony Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/shell/platform/linux_embedded/plugins/platform_views_plugin.h"
+
+#include "flutter/shell/platform/common/client_wrapper/include/flutter/standard_method_codec.h"
+#include "flutter/shell/platform/linux_embedded/logger.h"
+
+namespace flutter {
+
+namespace {
+constexpr char kChannelName[] = "flutter/platform_views";
+
+constexpr char kCreateMethod[] = "create";
+constexpr char kDisposeMethod[] = "dispose";
+constexpr char kResizeMethod[] = "resize";
+constexpr char kTouchMethod[] = "touch";
+constexpr char kSetDirectionMethod[] = "setDirection";
+constexpr char kClearFocusMethod[] = "clearFocus";
+}  // namespace
+
+PlatformViewsPlugin::PlatformViewsPlugin(BinaryMessenger* messenger)
+    : channel_(
+          std::make_unique<flutter::MethodChannel<flutter::EncodableValue>>(
+              messenger, kChannelName,
+              &flutter::StandardMethodCodec::GetInstance())) {
+  channel_->SetMethodCallHandler(
+      [this](const flutter::MethodCall<flutter::EncodableValue>& call,
+             std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>>
+                 result) { HandleMethodCall(call, std::move(result)); });
+}
+
+PlatformViewsPlugin::~PlatformViewsPlugin() {}
+
+void PlatformViewsPlugin::HandleMethodCall(
+    const flutter::MethodCall<flutter::EncodableValue>& method_call,
+    std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result) {
+  const auto& method = method_call.method_name();
+  const auto& arguments = *method_call.arguments();
+
+  LINUXES_LOG(DEBUG) << "Platform views: " << method << " is called.";
+  if (method.compare(kCreateMethod) == 0) {
+  } else if (method.compare(kDisposeMethod) == 0) {
+  } else if (method.compare(kResizeMethod) == 0) {
+  } else if (method.compare(kTouchMethod) == 0) {
+  } else if (method.compare(kSetDirectionMethod) == 0) {
+  } else if (method.compare(kClearFocusMethod) == 0) {
+  } else if (method.compare(kClearFocusMethod) == 0) {
+  } else {
+    result->NotImplemented();
+    return;
+  }
+  result->Success();
+}
+
+}  // namespace flutter

--- a/src/flutter/shell/platform/linux_embedded/plugins/platform_views_plugin.cc
+++ b/src/flutter/shell/platform/linux_embedded/plugins/platform_views_plugin.cc
@@ -67,7 +67,7 @@ PlatformViewsPlugin::~PlatformViewsPlugin() {
 
 void PlatformViewsPlugin::RegisterViewFactory(
     const char* view_type,
-    std::unique_ptr<FlutterPlatformViewFactory> factory) {
+    std::unique_ptr<FlutterDesktopPlatformViewFactory> factory) {
   if (platform_view_factories_.find(view_type) !=
       platform_view_factories_.end()) {
     LINUXES_LOG(ERROR) << "Platform Views factory is already registered: "

--- a/src/flutter/shell/platform/linux_embedded/plugins/platform_views_plugin.cc
+++ b/src/flutter/shell/platform/linux_embedded/plugins/platform_views_plugin.cc
@@ -28,17 +28,6 @@ constexpr char kIdKey[] = "id";
 constexpr char kWidthKey[] = "width";
 constexpr char kHeightKey[] = "height";
 constexpr char kParamsKey[] = "params";
-
-template <typename T>
-T LookupEncodableMap(const flutter::EncodableValue& map, const char* key) {
-  auto values = std::get<flutter::EncodableMap>(map);
-  auto value = values[flutter::EncodableValue(key)];
-  if (!std::holds_alternative<T>(value)) {
-    return T();
-  }
-  return std::get<T>(value);
-}
-
 }  // namespace
 
 PlatformViewsPlugin::PlatformViewsPlugin(BinaryMessenger* messenger)

--- a/src/flutter/shell/platform/linux_embedded/plugins/platform_views_plugin.cc
+++ b/src/flutter/shell/platform/linux_embedded/plugins/platform_views_plugin.cc
@@ -15,23 +15,67 @@ constexpr char kChannelName[] = "flutter/platform_views";
 constexpr char kCreateMethod[] = "create";
 constexpr char kDisposeMethod[] = "dispose";
 constexpr char kResizeMethod[] = "resize";
-constexpr char kTouchMethod[] = "touch";
 constexpr char kSetDirectionMethod[] = "setDirection";
 constexpr char kClearFocusMethod[] = "clearFocus";
+constexpr char kTouchMethod[] = "touch";
+constexpr char kAcceptGestureMethod[] = "acceptGesture";
+constexpr char kRejectGestureMethod[] = "rejectGesture";
+constexpr char kEnterMethod[] = "enter";
+constexpr char kExitMethod[] = "exit";
+
+constexpr char kViewType[] = "viewType";
+constexpr char kId[] = "id";
+constexpr char kWidth[] = "width";
+constexpr char kHeight[] = "height";
+constexpr char kParams[] = "params";
+
+template <typename T>
+T LookupEncodableMap(const flutter::EncodableValue& map, const char* key) {
+  auto values = std::get<flutter::EncodableMap>(map);
+  auto value = values[flutter::EncodableValue(key)];
+  if (!std::holds_alternative<T>(value)) {
+    return T();
+  }
+  return std::get<T>(value);
+}
+
 }  // namespace
 
 PlatformViewsPlugin::PlatformViewsPlugin(BinaryMessenger* messenger)
     : channel_(
           std::make_unique<flutter::MethodChannel<flutter::EncodableValue>>(
               messenger, kChannelName,
-              &flutter::StandardMethodCodec::GetInstance())) {
+              &flutter::StandardMethodCodec::GetInstance())),
+      current_view_id_(-1) {
   channel_->SetMethodCallHandler(
       [this](const flutter::MethodCall<flutter::EncodableValue>& call,
              std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>>
                  result) { HandleMethodCall(call, std::move(result)); });
 }
 
-PlatformViewsPlugin::~PlatformViewsPlugin() {}
+PlatformViewsPlugin::~PlatformViewsPlugin() {
+  for (auto& itr : platform_views_) {
+    delete itr.second;
+  }
+  platform_views_.clear();
+
+  for (auto& itr : platform_view_factories_) {
+    itr.second->Dispose();
+  }
+  platform_view_factories_.clear();
+}
+
+void PlatformViewsPlugin::RegisterViewFactory(
+    const char* view_type,
+    std::unique_ptr<FlutterPlatformViewFactory> factory) {
+  if (platform_view_factories_.find(view_type) !=
+      platform_view_factories_.end()) {
+    LINUXES_LOG(ERROR) << "Platform Views factory is already registered: "
+                       << view_type;
+    return;
+  }
+  platform_view_factories_[view_type] = std::move(factory);
+}
 
 void PlatformViewsPlugin::HandleMethodCall(
     const flutter::MethodCall<flutter::EncodableValue>& method_call,
@@ -39,18 +83,96 @@ void PlatformViewsPlugin::HandleMethodCall(
   const auto& method = method_call.method_name();
   const auto& arguments = *method_call.arguments();
 
-  LINUXES_LOG(DEBUG) << "Platform views: " << method << " is called.";
+  // todo: support all of the methods on the platform views.
   if (method.compare(kCreateMethod) == 0) {
+    PlatformViewsCreate(arguments, std::move(result));
   } else if (method.compare(kDisposeMethod) == 0) {
+    PlatformViewsDispose(arguments, std::move(result));
   } else if (method.compare(kResizeMethod) == 0) {
-  } else if (method.compare(kTouchMethod) == 0) {
+    result->NotImplemented();
   } else if (method.compare(kSetDirectionMethod) == 0) {
+    result->NotImplemented();
   } else if (method.compare(kClearFocusMethod) == 0) {
-  } else if (method.compare(kClearFocusMethod) == 0) {
+    result->NotImplemented();
+  } else if (method.compare(kTouchMethod) == 0) {
+    result->NotImplemented();
+  } else if (method.compare(kAcceptGestureMethod) == 0) {
+    result->NotImplemented();
+  } else if (method.compare(kRejectGestureMethod) == 0) {
+    result->NotImplemented();
+  } else if (method.compare(kEnterMethod) == 0) {
+    result->NotImplemented();
+  } else if (method.compare(kExitMethod) == 0) {
+    result->NotImplemented();
   } else {
     result->NotImplemented();
+  }
+}
+
+void PlatformViewsPlugin::PlatformViewsCreate(
+    const flutter::EncodableValue& arguments,
+    std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result) {
+  auto view_type = LookupEncodableMap<std::string>(arguments, kViewType);
+  if (view_type.empty()) {
+    result->Error("Couldn't find the view type in the arguments");
     return;
   }
+  auto view_id = LookupEncodableMap<int>(arguments, kId);
+  if (!view_id) {
+    result->Error("Couldn't find the view id in the arguments");
+    return;
+  }
+  auto view_width = LookupEncodableMap<double>(arguments, kWidth);
+  if (!view_width) {
+    result->Error("Couldn't find width in the arguments");
+    return;
+  }
+  auto view_height = LookupEncodableMap<double>(arguments, kHeight);
+  if (!view_height) {
+    result->Error("Couldn't find height in the arguments");
+    return;
+  }
+  LINUXES_LOG(DEBUG) << "Create the platform view: view_type = " << view_type
+                     << ", id = " << view_id << ", width = " << view_width
+                     << ", height = " << view_height;
+
+  if (platform_view_factories_.find(view_type) ==
+      platform_view_factories_.end()) {
+    result->Error("Couldn't find the view type");
+    return;
+  }
+
+  auto params = LookupEncodableMap<std::vector<uint8_t>>(arguments, kParams);
+  auto view = platform_view_factories_[view_type]->Create(view_id, view_width,
+                                                          view_height, params);
+  if (view) {
+    platform_views_[view_id] = view;
+    result->Success(flutter::EncodableValue(view->GetTextureId()));
+  } else {
+    result->Error("Failed to create a platform view");
+  }
+
+  if (platform_views_.find(current_view_id_) != platform_views_.end()) {
+    platform_views_[current_view_id_]->SetFocus(false);
+  }
+  current_view_id_ = view_id;
+}
+
+void PlatformViewsPlugin::PlatformViewsDispose(
+    const flutter::EncodableValue& arguments,
+    std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result) {
+  auto view_id = LookupEncodableMap<int>(arguments, kId);
+  if (!view_id) {
+    result->Error("Couldn't find the view id in the arguments");
+    return;
+  }
+
+  LINUXES_LOG(DEBUG) << "Dispose the platform view: id = " << view_id;
+  if (platform_views_.find(view_id) == platform_views_.end()) {
+    result->Error("Couldn't find the view id in the arguments");
+    return;
+  }
+  platform_views_[view_id]->Dispose();
   result->Success();
 }
 

--- a/src/flutter/shell/platform/linux_embedded/plugins/platform_views_plugin.cc
+++ b/src/flutter/shell/platform/linux_embedded/plugins/platform_views_plugin.cc
@@ -4,7 +4,6 @@
 
 #include "flutter/shell/platform/linux_embedded/plugins/platform_views_plugin.h"
 
-#include "flutter/shell/platform/common/client_wrapper/include/flutter/standard_method_codec.h"
 #include "flutter/shell/platform/linux_embedded/logger.h"
 
 namespace flutter {

--- a/src/flutter/shell/platform/linux_embedded/plugins/platform_views_plugin.cc
+++ b/src/flutter/shell/platform/linux_embedded/plugins/platform_views_plugin.cc
@@ -137,15 +137,15 @@ void PlatformViewsPlugin::PlatformViewsCreate(
                                                           view_height, params);
   if (view) {
     platform_views_[view_id] = view;
+    if (platform_views_.find(current_view_id_) != platform_views_.end()) {
+      platform_views_[current_view_id_]->SetFocus(false);
+    }
+    current_view_id_ = view_id;
+
     result->Success(flutter::EncodableValue(view->GetTextureId()));
   } else {
     result->Error("Failed to create a platform view");
   }
-
-  if (platform_views_.find(current_view_id_) != platform_views_.end()) {
-    platform_views_[current_view_id_]->SetFocus(false);
-  }
-  current_view_id_ = view_id;
 }
 
 void PlatformViewsPlugin::PlatformViewsDispose(

--- a/src/flutter/shell/platform/linux_embedded/plugins/platform_views_plugin.cc
+++ b/src/flutter/shell/platform/linux_embedded/plugins/platform_views_plugin.cc
@@ -23,11 +23,11 @@ constexpr char kRejectGestureMethod[] = "rejectGesture";
 constexpr char kEnterMethod[] = "enter";
 constexpr char kExitMethod[] = "exit";
 
-constexpr char kViewType[] = "viewType";
-constexpr char kId[] = "id";
-constexpr char kWidth[] = "width";
-constexpr char kHeight[] = "height";
-constexpr char kParams[] = "params";
+constexpr char kViewTypeKey[] = "viewType";
+constexpr char kIdKey[] = "id";
+constexpr char kWidthKey[] = "width";
+constexpr char kHeightKey[] = "height";
+constexpr char kParamsKey[] = "params";
 
 template <typename T>
 T LookupEncodableMap(const flutter::EncodableValue& map, const char* key) {
@@ -105,6 +105,8 @@ void PlatformViewsPlugin::HandleMethodCall(
   } else if (method.compare(kExitMethod) == 0) {
     result->NotImplemented();
   } else {
+    LINUXES_LOG(WARNING) << "Platform Views unexpected method is called: "
+                         << method;
     result->NotImplemented();
   }
 }
@@ -112,22 +114,22 @@ void PlatformViewsPlugin::HandleMethodCall(
 void PlatformViewsPlugin::PlatformViewsCreate(
     const flutter::EncodableValue& arguments,
     std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result) {
-  auto view_type = LookupEncodableMap<std::string>(arguments, kViewType);
+  auto view_type = LookupEncodableMap<std::string>(arguments, kViewTypeKey);
   if (view_type.empty()) {
     result->Error("Couldn't find the view type in the arguments");
     return;
   }
-  auto view_id = LookupEncodableMap<int>(arguments, kId);
+  auto view_id = LookupEncodableMap<int>(arguments, kIdKey);
   if (!view_id) {
     result->Error("Couldn't find the view id in the arguments");
     return;
   }
-  auto view_width = LookupEncodableMap<double>(arguments, kWidth);
+  auto view_width = LookupEncodableMap<double>(arguments, kWidthKey);
   if (!view_width) {
     result->Error("Couldn't find width in the arguments");
     return;
   }
-  auto view_height = LookupEncodableMap<double>(arguments, kHeight);
+  auto view_height = LookupEncodableMap<double>(arguments, kHeightKey);
   if (!view_height) {
     result->Error("Couldn't find height in the arguments");
     return;
@@ -142,7 +144,7 @@ void PlatformViewsPlugin::PlatformViewsCreate(
     return;
   }
 
-  auto params = LookupEncodableMap<std::vector<uint8_t>>(arguments, kParams);
+  auto params = LookupEncodableMap<std::vector<uint8_t>>(arguments, kParamsKey);
   auto view = platform_view_factories_[view_type]->Create(view_id, view_width,
                                                           view_height, params);
   if (view) {
@@ -161,7 +163,7 @@ void PlatformViewsPlugin::PlatformViewsCreate(
 void PlatformViewsPlugin::PlatformViewsDispose(
     const flutter::EncodableValue& arguments,
     std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result) {
-  auto view_id = LookupEncodableMap<int>(arguments, kId);
+  auto view_id = LookupEncodableMap<int>(arguments, kIdKey);
   if (!view_id) {
     result->Error("Couldn't find the view id in the arguments");
     return;

--- a/src/flutter/shell/platform/linux_embedded/plugins/platform_views_plugin.h
+++ b/src/flutter/shell/platform/linux_embedded/plugins/platform_views_plugin.h
@@ -1,0 +1,31 @@
+// Copyright 2021 Sony Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_SHELL_PLATFORM_LINUX_EMBEDDED_PLUGINS_PLATFORM_VIEWS_PLUGIN_H_
+#define FLUTTER_SHELL_PLATFORM_LINUX_EMBEDDED_PLUGINS_PLATFORM_VIEWS_PLUGIN_H_
+
+#include <memory>
+
+#include "flutter/shell/platform/common/client_wrapper/include/flutter/binary_messenger.h"
+#include "flutter/shell/platform/common/client_wrapper/include/flutter/method_channel.h"
+
+namespace flutter {
+
+class PlatformViewsPlugin {
+ public:
+  PlatformViewsPlugin(BinaryMessenger* messenger);
+  ~PlatformViewsPlugin();
+
+ private:
+  // Called when a method is called on |channel_|;
+  void HandleMethodCall(
+      const flutter::MethodCall<flutter::EncodableValue>& method_call,
+      std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result);
+
+  std::unique_ptr<flutter::MethodChannel<flutter::EncodableValue>> channel_;
+};
+
+}  // namespace flutter
+
+#endif  // FLUTTER_SHELL_PLATFORM_LINUX_EMBEDDED_PLUGINS_PLATFORM_VIEWS_PLUGIN_H_

--- a/src/flutter/shell/platform/linux_embedded/plugins/platform_views_plugin.h
+++ b/src/flutter/shell/platform/linux_embedded/plugins/platform_views_plugin.h
@@ -10,6 +10,7 @@
 
 #include "flutter/shell/platform/common/client_wrapper/include/flutter/binary_messenger.h"
 #include "flutter/shell/platform/common/client_wrapper/include/flutter/method_channel.h"
+#include "flutter/shell/platform/common/client_wrapper/include/flutter/standard_method_codec.h"
 #include "flutter/shell/platform/linux_embedded/public/flutter_platform_views.h"
 
 namespace flutter {

--- a/src/flutter/shell/platform/linux_embedded/plugins/platform_views_plugin.h
+++ b/src/flutter/shell/platform/linux_embedded/plugins/platform_views_plugin.h
@@ -30,6 +30,17 @@ class PlatformViewsPlugin {
       const flutter::MethodCall<flutter::EncodableValue>& method_call,
       std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result);
 
+  // Decodes and gets a value from an argument of MethodCall.
+  template <typename T>
+  T LookupEncodableMap(const flutter::EncodableValue& map, const char* key) {
+    auto values = std::get<flutter::EncodableMap>(map);
+    auto value = values[flutter::EncodableValue(key)];
+    if (!std::holds_alternative<T>(value)) {
+      return T();
+    }
+    return std::get<T>(value);
+  }
+
   // Called when "create" method is called
   void PlatformViewsCreate(
       const flutter::EncodableValue& arguments,

--- a/src/flutter/shell/platform/linux_embedded/plugins/platform_views_plugin.h
+++ b/src/flutter/shell/platform/linux_embedded/plugins/platform_views_plugin.h
@@ -48,7 +48,7 @@ class PlatformViewsPlugin {
                      std::unique_ptr<FlutterDesktopPlatformViewFactory>>
       platform_view_factories_;
 
-  // Platform views (instances).
+  // Instances of platform views.
   std::unordered_map<int, FlutterDesktopPlatformView*> platform_views_;
 
   // Shows the id of current view.

--- a/src/flutter/shell/platform/linux_embedded/plugins/platform_views_plugin.h
+++ b/src/flutter/shell/platform/linux_embedded/plugins/platform_views_plugin.h
@@ -20,8 +20,9 @@ class PlatformViewsPlugin {
   ~PlatformViewsPlugin();
 
   // Registers a factory of the platform view.
-  void RegisterViewFactory(const char* view_type,
-                           std::unique_ptr<FlutterPlatformViewFactory> factory);
+  void RegisterViewFactory(
+      const char* view_type,
+      std::unique_ptr<FlutterDesktopPlatformViewFactory> factory);
 
  private:
   // Called when a method is called on |channel_|;
@@ -43,11 +44,12 @@ class PlatformViewsPlugin {
   std::unique_ptr<flutter::MethodChannel<flutter::EncodableValue>> channel_;
 
   // Factory of PlatformView class.
-  std::unordered_map<std::string, std::unique_ptr<FlutterPlatformViewFactory>>
+  std::unordered_map<std::string,
+                     std::unique_ptr<FlutterDesktopPlatformViewFactory>>
       platform_view_factories_;
 
   // Platform views (instances).
-  std::unordered_map<int, FlutterPlatformView*> platform_views_;
+  std::unordered_map<int, FlutterDesktopPlatformView*> platform_views_;
 
   // Shows the id of current view.
   int current_view_id_;

--- a/src/flutter/shell/platform/linux_embedded/plugins/platform_views_plugin.h
+++ b/src/flutter/shell/platform/linux_embedded/plugins/platform_views_plugin.h
@@ -6,9 +6,11 @@
 #define FLUTTER_SHELL_PLATFORM_LINUX_EMBEDDED_PLUGINS_PLATFORM_VIEWS_PLUGIN_H_
 
 #include <memory>
+#include <unordered_map>
 
 #include "flutter/shell/platform/common/client_wrapper/include/flutter/binary_messenger.h"
 #include "flutter/shell/platform/common/client_wrapper/include/flutter/method_channel.h"
+#include "flutter/shell/platform/linux_embedded/public/flutter_platform_views.h"
 
 namespace flutter {
 
@@ -17,13 +19,38 @@ class PlatformViewsPlugin {
   PlatformViewsPlugin(BinaryMessenger* messenger);
   ~PlatformViewsPlugin();
 
+  // Registers a factory of the platform view.
+  void RegisterViewFactory(const char* view_type,
+                           std::unique_ptr<PlatformViewFactory> factory);
+
  private:
   // Called when a method is called on |channel_|;
   void HandleMethodCall(
       const flutter::MethodCall<flutter::EncodableValue>& method_call,
       std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result);
 
+  // Called when "create" method is called
+  void PlatformViewsCreate(
+      const flutter::EncodableValue& arguments,
+      std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result);
+
+  // Called when "dispose" method is called
+  void PlatformViewsDispose(
+      const flutter::EncodableValue& arguments,
+      std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result);
+
+  // Method channel instance.
   std::unique_ptr<flutter::MethodChannel<flutter::EncodableValue>> channel_;
+
+  // Factory of PlatformView class.
+  std::unordered_map<std::string, std::unique_ptr<FlutterPlatformViewFactory>>
+      platform_view_factories_;
+
+  // Platform views (instances).
+  std::unordered_map<int, FlutterPlatformView*> platform_views_;
+
+  // Shows the id of current view.
+  int current_view_id_;
 };
 
 }  // namespace flutter

--- a/src/flutter/shell/platform/linux_embedded/plugins/platform_views_plugin.h
+++ b/src/flutter/shell/platform/linux_embedded/plugins/platform_views_plugin.h
@@ -21,7 +21,7 @@ class PlatformViewsPlugin {
 
   // Registers a factory of the platform view.
   void RegisterViewFactory(const char* view_type,
-                           std::unique_ptr<PlatformViewFactory> factory);
+                           std::unique_ptr<FlutterPlatformViewFactory> factory);
 
  private:
   // Called when a method is called on |channel_|;

--- a/src/flutter/shell/platform/linux_embedded/public/flutter_platform_views.h
+++ b/src/flutter/shell/platform/linux_embedded/public/flutter_platform_views.h
@@ -68,7 +68,7 @@ extern "C" {
 
 void FlutterDesktopRegisterPlatformViewFactory(
     FlutterDesktopPluginRegistrarRef registrar, const char* view_type,
-    std::unique_ptr<FlutterDesktopPlatformViewFactory> view_factory)
+    std::unique_ptr<FlutterDesktopPlatformViewFactory> view_factory);
 
 #if defined(__cplusplus)
 }  // extern "C"

--- a/src/flutter/shell/platform/linux_embedded/public/flutter_platform_views.h
+++ b/src/flutter/shell/platform/linux_embedded/public/flutter_platform_views.h
@@ -1,0 +1,64 @@
+// Copyright 2021 Sony Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_SHELL_PLATFORM_LINUX_EMBEDDED_PUBLIC_FLUTTER_PLATFORM_VIEWS_H_
+#define FLUTTER_SHELL_PLATFORM_LINUX_EMBEDDED_PUBLIC_FLUTTER_PLATFORM_VIEWS_H_
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include <memory>
+
+#include "flutter_export.h"
+#include "flutter_messenger.h"
+#include "plugin_registrar.h"
+
+class FlutterPlatformView {
+ public:
+  FlutterPlatformView(flutter::PluginRegistrar* registrar, int view_id)
+      : registrar_(registrar),
+        view_id_(view_id),
+        texture_id_(-1),
+        focused_(false) {}
+  virtual ~FlutterPlatformView() {}
+
+  flutter::PluginRegistrar* GetPluginRegistrar() { return registrar_; }
+
+  virtual void Dispose() = 0;
+
+  int GetViewId() const { return view_id_; }
+
+  void SetFocus(bool focus) { focused_ = focus; }
+
+  bool IsFocused() const { return focused_; }
+
+  void SetTextureId(int texture_id) { texture_id_ = texture_id; }
+
+  int GetTextureId() const { return texture_id_; }
+
+ private:
+  flutter::PluginRegistrar* registrar_;
+  int view_id_;
+  int texture_id_;
+  bool focused_;
+};
+
+class FlutterPlatformViewFactory {
+ public:
+  FlutterPlatformViewFactory(flutter::PluginRegistrar* registrar)
+      : registrar_(registrar) {}
+  virtual ~FlutterPlatformViewFactory() {}
+
+  flutter::PluginRegistrar* GetPluginRegistrar() const { return registrar_; }
+
+  virtual FlutterPlatformView* Create(int view_id, double width, double height,
+                                      const std::vector<uint8_t>& params) = 0;
+
+  virtual void Dispose() = 0;
+
+ private:
+  flutter::PluginRegistrar* registrar_;
+};
+
+#endif  // FLUTTER_SHELL_PLATFORM_LINUX_EMBEDDED_PUBLIC_FLUTTER_PLATFORM_VIEWS_H_

--- a/src/flutter/shell/platform/linux_embedded/public/flutter_platform_views.h
+++ b/src/flutter/shell/platform/linux_embedded/public/flutter_platform_views.h
@@ -14,14 +14,14 @@
 #include "flutter_messenger.h"
 #include "plugin_registrar.h"
 
-class FlutterPlatformView {
+class FlutterDesktopPlatformView {
  public:
-  FlutterPlatformView(flutter::PluginRegistrar* registrar, int view_id)
+  FlutterDesktopPlatformView(flutter::PluginRegistrar* registrar, int view_id)
       : registrar_(registrar),
         view_id_(view_id),
         texture_id_(-1),
         focused_(false) {}
-  virtual ~FlutterPlatformView() {}
+  virtual ~FlutterDesktopPlatformView() {}
 
   flutter::PluginRegistrar* GetPluginRegistrar() { return registrar_; }
 
@@ -44,16 +44,17 @@ class FlutterPlatformView {
   bool focused_;
 };
 
-class FlutterPlatformViewFactory {
+class FlutterDesktopPlatformViewFactory {
  public:
-  FlutterPlatformViewFactory(flutter::PluginRegistrar* registrar)
+  FlutterDesktopPlatformViewFactory(flutter::PluginRegistrar* registrar)
       : registrar_(registrar) {}
-  virtual ~FlutterPlatformViewFactory() {}
+  virtual ~FlutterDesktopPlatformViewFactory() {}
 
   flutter::PluginRegistrar* GetPluginRegistrar() const { return registrar_; }
 
-  virtual FlutterPlatformView* Create(int view_id, double width, double height,
-                                      const std::vector<uint8_t>& params) = 0;
+  virtual FlutterDesktopPlatformView* Create(
+      int view_id, double width, double height,
+      const std::vector<uint8_t>& params) = 0;
 
   virtual void Dispose() = 0;
 

--- a/src/flutter/shell/platform/linux_embedded/public/flutter_platform_views.h
+++ b/src/flutter/shell/platform/linux_embedded/public/flutter_platform_views.h
@@ -62,4 +62,16 @@ class FlutterDesktopPlatformViewFactory {
   flutter::PluginRegistrar* registrar_;
 };
 
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+void FlutterDesktopRegisterPlatformViewFactory(
+    FlutterDesktopPluginRegistrarRef registrar, const char* view_type,
+    std::unique_ptr<FlutterDesktopPlatformViewFactory> view_factory)
+
+#if defined(__cplusplus)
+}  // extern "C"
+#endif
+
 #endif  // FLUTTER_SHELL_PLATFORM_LINUX_EMBEDDED_PUBLIC_FLUTTER_PLATFORM_VIEWS_H_


### PR DESCRIPTION
I added the first implementation of the platform views plugin. However, it isn't completed yet such as touch, resize, and so on.

## Related issues
- https://github.com/sony/flutter-embedded-linux/issues/41