### PR TITLE
Fix link error of libflutter_elinux_*.so

### DIFF
--- a/cmake/build.cmake
+++ b/cmake/build.cmake
@@ -165,6 +165,8 @@ else()
   add_library(${TARGET}
     SHARED
       ${ELINUX_COMMON_SRC}
+      ${CPP_WRAPPER_SOURCES_CORE}
+      ${CPP_WRAPPER_SOURCES_PLUGIN}
   )
 
   target_include_directories(${TARGET}


### PR DESCRIPTION
I fixed the link error of libflutter_elinux_*.so.