### PR TITLE
Add FLUTTER_RELEASE CMake option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ option(DESKTOP_SHELL "Work as weston desktop-shell" OFF)
 option(USE_GLES3 "Use OpenGL ES3 (default is OpenGL ES2)" OFF)
 option(BUILD_ELINUX_SO "Build .so file of elinux embedder" OFF)
 option(ENABLE_ELINUX_EMBEDDER_LOG "Enable logger of eLinux embedder" ON)
+option(FLUTTER_RELEASE "Build Flutter Engine with release mode" OFF)
 
 if(NOT BUILD_ELINUX_SO)
   # Load the user project.

--- a/cmake/build.cmake
+++ b/cmake/build.cmake
@@ -94,7 +94,7 @@ if(USE_GLES3)
 endif()
 
 # Flutter embedder runtime mode.
-if(NOT CMAKE_BUILD_TYPE MATCHES Debug)
+if(FLUTTER_RELEASE)
   add_definitions(
     -DFLUTTER_RELEASE # release mode
   )


### PR DESCRIPTION
I added `FLUTTER_RELEASE` cmake option to separate it from `CMAKE_BUILD_TYPE`.