### PR TITLE
Fix wrong touch input

### DIFF
--- a/src/flutter/shell/platform/linux_embedded/flutter_elinux_view.cc
+++ b/src/flutter/shell/platform/linux_embedded/flutter_elinux_view.cc
@@ -10,6 +10,10 @@
 
 namespace flutter {
 
+namespace {
+constexpr int kMicrosecondsPerMillisecond = 1000;
+}  // namespace
+
 FlutterELinuxView::FlutterELinuxView(
     std::unique_ptr<WindowBindingHandler> window_binding) {
   // Take the binding handler, and give it a pointer back to self.
@@ -106,12 +110,11 @@ void FlutterELinuxView::OnTouchDown(uint32_t time, int32_t id, double x,
   point->event_mask = TouchEvent::kDown;
   point->x = x;
   point->y = y;
-  touch_event_.time = time;
 
   FlutterPointerEvent event = {
       .struct_size = sizeof(event),
       .phase = FlutterPointerPhase::kDown,
-      .timestamp = time,
+      .timestamp = time * kMicrosecondsPerMillisecond,
       .x = x,
       .y = y,
       .device = id,
@@ -134,7 +137,7 @@ void FlutterELinuxView::OnTouchUp(uint32_t time, int32_t id) {
   FlutterPointerEvent event = {
       .struct_size = sizeof(event),
       .phase = FlutterPointerPhase::kUp,
-      .timestamp = time,
+      .timestamp = time * kMicrosecondsPerMillisecond,
       .x = point->x,
       .y = point->y,
       .device = id,
@@ -156,12 +159,11 @@ void FlutterELinuxView::OnTouchMotion(uint32_t time, int32_t id, double x,
   point->event_mask = TouchEvent::kMotion;
   point->x = x;
   point->y = y;
-  touch_event_.time = time;
 
   FlutterPointerEvent event = {
       .struct_size = sizeof(event),
       .phase = FlutterPointerPhase::kMove,
-      .timestamp = time,
+      .timestamp = time * kMicrosecondsPerMillisecond,
       .x = x,
       .y = y,
       .device = id,

--- a/src/flutter/shell/platform/linux_embedded/flutter_elinux_view.h
+++ b/src/flutter/shell/platform/linux_embedded/flutter_elinux_view.h
@@ -166,7 +166,6 @@ class FlutterELinuxView : public WindowBindingHandlerDelegate {
   };
 
   struct touch_event {
-    uint32_t time;
     touch_point points[10];
   };
 

--- a/src/flutter/shell/platform/linux_embedded/window_binding_handler_delegate.h
+++ b/src/flutter/shell/platform/linux_embedded/window_binding_handler_delegate.h
@@ -36,23 +36,23 @@ class WindowBindingHandlerDelegate {
   // Notifies delegate that backing window touch pointer has been pressed.
   // Typically called by currently configured WindowBindingHandler
   // @param[in]  time    Monotonically increasing timestamp in milliseconds.
-  // @param[in]  id      The unique ID of this touch point.
+  // @param[in]  id      The unique id of this touch point.
   // @param[in]  x       The Surface local x coordinate.
-  // @param[in]  y       The Surface local x coordinate.
+  // @param[in]  y       The Surface local y coordinate.
   virtual void OnTouchDown(uint32_t time, int32_t id, double x, double y) = 0;
 
   // Notifies delegate that backing window touch pointer has been released.
   // Typically called by currently configured WindowBindingHandler
   // @param[in]  time    Monotonically increasing timestamp in milliseconds.
-  // @param[in]  id      The unique ID of this touch point.
+  // @param[in]  id      The unique id of this touch point.
   virtual void OnTouchUp(uint32_t time, int32_t id) = 0;
 
   // Notifies delegate that backing window touch pointer has moved.
   // Typically called by currently configured WindowBindingHandler
   // @param[in]  time    Monotonically increasing timestamp in milliseconds.
-  // @param[in]  id      The unique ID of this touch point.
+  // @param[in]  id      The unique id of this touch point.
   // @param[in]  x       The Surface local x coordinate.
-  // @param[in]  y       The Surface local x coordinate.
+  // @param[in]  y       The Surface local y coordinate.
   virtual void OnTouchMotion(uint32_t time, int32_t id, double x, double y) = 0;
 
   // Notifies delegate that backing window touch pointer has been canceled.

--- a/src/flutter/shell/platform/linux_embedded/window_binding_handler_delegate.h
+++ b/src/flutter/shell/platform/linux_embedded/window_binding_handler_delegate.h
@@ -35,14 +35,24 @@ class WindowBindingHandlerDelegate {
 
   // Notifies delegate that backing window touch pointer has been pressed.
   // Typically called by currently configured WindowBindingHandler
+  // @param[in]  time    Monotonically increasing timestamp in milliseconds.
+  // @param[in]  id      The unique ID of this touch point.
+  // @param[in]  x       The Surface local x coordinate.
+  // @param[in]  y       The Surface local x coordinate.
   virtual void OnTouchDown(uint32_t time, int32_t id, double x, double y) = 0;
 
   // Notifies delegate that backing window touch pointer has been released.
   // Typically called by currently configured WindowBindingHandler
+  // @param[in]  time    Monotonically increasing timestamp in milliseconds.
+  // @param[in]  id      The unique ID of this touch point.
   virtual void OnTouchUp(uint32_t time, int32_t id) = 0;
 
   // Notifies delegate that backing window touch pointer has moved.
   // Typically called by currently configured WindowBindingHandler
+  // @param[in]  time    Monotonically increasing timestamp in milliseconds.
+  // @param[in]  id      The unique ID of this touch point.
+  // @param[in]  x       The Surface local x coordinate.
+  // @param[in]  y       The Surface local x coordinate.
   virtual void OnTouchMotion(uint32_t time, int32_t id, double x, double y) = 0;
 
   // Notifies delegate that backing window touch pointer has been canceled.


### PR DESCRIPTION
I fixed the touch-input bug in https://github.com/sony/flutter-embedded-linux/issues/127, which caused by the wrong time unit.

#### Timestamps
- Wayland: milliseconds (https://wayland-book.com/seat/touch.html#touch-and-release)
- DRM (GBM/EGLStream): milliseconds (libinput_event_touch_get_time)
- Flutter Engine: microseconds (https://github.com/flutter/engine/blob/master/shell/platform/embedder/embedder.h#L651)

See: https://github.com/sony/flutter-embedded-linux/issues/127#issuecomment-914054958

Thanks a lot, @anyuliu
(cc @jcviau)