### PR TITLE
Fix synchronized frame on Wayland

### DIFF
--- a/src/flutter/shell/platform/linux_embedded/surface/elinux_egl_surface.cc
+++ b/src/flutter/shell/platform/linux_embedded/surface/elinux_egl_surface.cc
@@ -31,6 +31,15 @@ bool ELinuxEGLSurface::MakeCurrent() const {
                       << get_egl_error_cause();
     return false;
   }
+
+#if defined(DISPLAY_BACKEND_TYPE_WAYLAND)
+  // Non-blocking when swappipping buffers on Wayland.
+  if (eglSwapInterval(display_, 0) != EGL_TRUE) {
+    ELINUX_LOG(ERROR) << "Failed to eglSwapInterval(Free): "
+                      << get_egl_error_cause();
+  }
+#endif
+
   return true;
 }
 


### PR DESCRIPTION
Currently, the embedder always waits for the next Vsync when flutter calls `eglSwapBuffers`.

Fixed https://github.com/sony/flutter-embedded-linux/issues/220