### PR TITLE
[wayland] Fix crashes with `xdg_surface buffer does not match the configured state`

### DIFF
--- a/src/flutter/shell/platform/linux_embedded/window/elinux_window_wayland.cc
+++ b/src/flutter/shell/platform/linux_embedded/window/elinux_window_wayland.cc
@@ -63,6 +63,10 @@ const xdg_wm_base_listener ELinuxWindowWayland::kXdgWmBaseListener = {
 const xdg_surface_listener ELinuxWindowWayland::kXdgSurfaceListener = {
     .configure =
         [](void* data, xdg_surface* xdg_surface, uint32_t serial) {
+          auto self = reinterpret_cast<ELinuxWindowWayland*>(data);
+          xdg_surface_set_window_geometry(xdg_surface, 0, 0,
+                                          self->view_properties_.width,
+                                          self->view_properties_.height);
           xdg_surface_ack_configure(xdg_surface, serial);
         },
 };


### PR DESCRIPTION
## Issue
1. Run a flutter app with the window decorations on Weston 8.0
2. Press the maximize button

```
[15:42:27.378] libwayland: error in client communication (pid 20431)
xdg_wm_base@11: error 4: xdg_surface buffer does not match the configured state
```

I'm not sure, but this issue doesn't happen on Gnome Wayland.