### PR TITLE
[wayland] Fix operations of the max button in the window decorations

### DIFF
--- a/src/flutter/shell/platform/linux_embedded/window/elinux_window_wayland.cc
+++ b/src/flutter/shell/platform/linux_embedded/window/elinux_window_wayland.cc
@@ -64,7 +64,15 @@ const xdg_surface_listener ELinuxWindowWayland::kXdgSurfaceListener = {
     .configure =
         [](void* data, xdg_surface* xdg_surface, uint32_t serial) {
           auto self = reinterpret_cast<ELinuxWindowWayland*>(data);
-          xdg_surface_set_window_geometry(xdg_surface, 0, 0,
+          constexpr int32_t x = 0;
+          int32_t y = 0;
+          if (self->view_properties_.use_window_decoration) {
+            // Moves the window to the bottom to show the window decorations,
+            // but the bottom area of the window will be hidden by the amount of
+            // shift.
+            y = -self->window_decorations_->Height();
+          }
+          xdg_surface_set_window_geometry(xdg_surface, x, y,
                                           self->view_properties_.width,
                                           self->view_properties_.height);
           xdg_surface_ack_configure(xdg_surface, serial);

--- a/src/flutter/shell/platform/linux_embedded/window/elinux_window_wayland.cc
+++ b/src/flutter/shell/platform/linux_embedded/window/elinux_window_wayland.cc
@@ -310,7 +310,7 @@ const wl_pointer_listener ELinuxWindowWayland::kWlPointerListener = {
           } else {
             // Stores original window size.
             self->restore_window_width_ = self->view_properties_.width;
-            self->restore_window_height_ = self->view_properties_.width;
+            self->restore_window_height_ = self->view_properties_.height;
             self->restore_window_required_ = false;
 
             xdg_toplevel_set_maximized(self->xdg_toplevel_);

--- a/src/flutter/shell/platform/linux_embedded/window/elinux_window_wayland.h
+++ b/src/flutter/shell/platform/linux_embedded/window/elinux_window_wayland.h
@@ -122,7 +122,7 @@ class ELinuxWindowWayland : public ELinuxWindow, public WindowBindingHandler {
   std::unique_ptr<WindowDecorationsWayland> window_decorations_;
   wl_surface* wl_current_surface_;
   wl_subcompositor* wl_subcompositor_;
-  bool    restore_window_required_ = false;
+  bool restore_window_required_ = false;
   int32_t restore_window_width_;
   int32_t restore_window_height_;
 

--- a/src/flutter/shell/platform/linux_embedded/window/elinux_window_wayland.h
+++ b/src/flutter/shell/platform/linux_embedded/window/elinux_window_wayland.h
@@ -122,6 +122,9 @@ class ELinuxWindowWayland : public ELinuxWindow, public WindowBindingHandler {
   std::unique_ptr<WindowDecorationsWayland> window_decorations_;
   wl_surface* wl_current_surface_;
   wl_subcompositor* wl_subcompositor_;
+  bool    restore_window_required_ = false;
+  int32_t restore_window_width_;
+  int32_t restore_window_height_;
 
   bool display_valid_;
   bool running_;

--- a/src/flutter/shell/platform/linux_embedded/window/renderer/window_decorations_wayland.cc
+++ b/src/flutter/shell/platform/linux_embedded/window/renderer/window_decorations_wayland.cc
@@ -114,4 +114,6 @@ void WindowDecorationsWayland::DestroyContext() {
   }
 }
 
+int32_t WindowDecorationsWayland::Height() const { return kTitleBarHeight; }
+
 }  // namespace flutter

--- a/src/flutter/shell/platform/linux_embedded/window/renderer/window_decorations_wayland.h
+++ b/src/flutter/shell/platform/linux_embedded/window/renderer/window_decorations_wayland.h
@@ -39,6 +39,8 @@ class WindowDecorationsWayland {
   bool IsMatched(wl_surface* surface,
                  WindowDecoration::DecorationType decoration_type) const;
 
+  int32_t Height() const;
+
  private:
   void DestroyContext();
 


### PR DESCRIPTION
## Changes
- Add restore original window size support (unset maximize-window)
- Fix the window decorations will be hidden after pressing the max-button

## Related issues
- https://github.com/sony/flutter-embedded-linux/issues/6