### PR TITLE
Rename enum value of FlutterDesktopViewMode

### DIFF
--- a/src/client_wrapper/flutter_view_controller.cc
+++ b/src/client_wrapper/flutter_view_controller.cc
@@ -28,7 +28,7 @@ FlutterViewController::FlutterViewController(
   c_view_properties.view_mode =
       (view_properties.view_mode == ViewMode::kFullscreen)
           ? FlutterDesktopViewMode::kFullscreen
-          : FlutterDesktopViewMode::kNormal;
+          : FlutterDesktopViewMode::kNormalscreen;
   c_view_properties.use_mouse_cursor = view_properties.use_mouse_cursor;
   c_view_properties.use_onscreen_keyboard =
       view_properties.use_onscreen_keyboard;

--- a/src/flutter/shell/platform/linux_embedded/public/flutter_elinux.h
+++ b/src/flutter/shell/platform/linux_embedded/public/flutter_elinux.h
@@ -57,7 +57,7 @@ typedef struct {
 // The View display mode.
 enum FlutterDesktopViewMode {
   // Shows the Flutter view by user specific size.
-  kNormal = 0,
+  kNormalscreen = 0,
   // Shows always the Flutter view by fullscreen.
   kFullscreen = 1,
 };


### PR DESCRIPTION
Renamed `FlutterDesktopViewMode` enum value to avoid conflict with the latest `embedder.h`