### PR TITLE
Use string message codec for lifecycle plugin

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -7,3 +7,4 @@
 Sony Group Corporation
 Hidenori Matsubayashi (hidenori.matsubayashi@gmail.com)
 Andrea Daoud (andreadaoud6@gmail.com)
+Valentin Hăloiu (valentin.haloiu@gmail.com)

--- a/cmake/build.cmake
+++ b/cmake/build.cmake
@@ -116,6 +116,7 @@ endif()
 set(CPP_WRAPPER_SOURCES_CORE
   "src/flutter/shell/platform/common/client_wrapper/engine_method_result.cc"
   "src/flutter/shell/platform/common/client_wrapper/standard_codec.cc"
+  "src/flutter/shell/platform/common/client_wrapper/string_message_codec.cc"
 )
 set(CPP_WRAPPER_SOURCES_PLUGIN
   "src/flutter/shell/platform/common/client_wrapper/plugin_registrar.cc"

--- a/src/flutter/shell/platform/common/client_wrapper/include/flutter/string_message_codec.h
+++ b/src/flutter/shell/platform/common/client_wrapper/include/flutter/string_message_codec.h
@@ -1,0 +1,45 @@
+// Copyright 2022 Sony Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef __CODE_FLUTTER_EMBEDDED_LINUX_SRC_FLUTTER_SHELL_PLATFORM_COMMON_CLIENT_WRAPPER_INCLUDE_FLUTTER_STRING_MESSAGE_CODEC_H_
+#define __CODE_FLUTTER_EMBEDDED_LINUX_SRC_FLUTTER_SHELL_PLATFORM_COMMON_CLIENT_WRAPPER_INCLUDE_FLUTTER_STRING_MESSAGE_CODEC_H_
+
+#include "message_codec.h"
+
+namespace flutter {
+
+// A message encoding/decoding mechanism for communications to/from the Flutter
+// engine via UTF-8 encoded string messages.
+//
+// This codec is guaranteed to be compatible with the corresponding
+// [StringCodec](https://api.flutter.dev/flutter/services/StringCodec-class.html)
+// on the Dart side. These parts of the Flutter SDK are evolved synchronously.
+class StringMessageCodec : public MessageCodec<std::string> {
+ public:
+  // Returns the shared instance of the codec.
+  static const StringMessageCodec& GetInstance();
+
+  ~StringMessageCodec() = default;
+
+  // Prevent copying.
+  StringMessageCodec(StringMessageCodec const&) = delete;
+  StringMessageCodec& operator=(StringMessageCodec const&) = delete;
+
+ protected:
+  // Instances should be obtained via GetInstance.
+  StringMessageCodec() = default;
+
+  // |flutter::MessageCodec|
+  std::unique_ptr<std::string> DecodeMessageInternal(
+      const uint8_t* binary_message,
+      const size_t message_size) const override;
+
+  // |flutter::MessageCodec|
+  std::unique_ptr<std::vector<uint8_t>> EncodeMessageInternal(
+      const std::string& message) const override;
+};
+
+}  // namespace flutter
+
+#endif  // __CODE_FLUTTER_EMBEDDED_LINUX_SRC_FLUTTER_SHELL_PLATFORM_COMMON_CLIENT_WRAPPER_INCLUDE_FLUTTER_STRING_MESSAGE_CODEC_H_

--- a/src/flutter/shell/platform/common/client_wrapper/string_message_codec.cc
+++ b/src/flutter/shell/platform/common/client_wrapper/string_message_codec.cc
@@ -1,0 +1,34 @@
+// Copyright 2022 Sony Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "include/flutter/string_message_codec.h"
+
+#include <string>
+
+namespace flutter {
+
+// static
+const StringMessageCodec& StringMessageCodec::GetInstance() {
+  static StringMessageCodec sInstance;
+  return sInstance;
+}
+
+std::unique_ptr<std::vector<uint8_t>> StringMessageCodec::EncodeMessageInternal(
+    const std::string& message) const {
+  return std::make_unique<std::vector<uint8_t>>(message.begin(), message.end());
+}
+
+std::unique_ptr<std::string> StringMessageCodec::DecodeMessageInternal(
+    const uint8_t* binary_message,
+    const size_t message_size) const {
+  if (!binary_message) {
+    return nullptr;
+  }
+
+  auto raw_message = reinterpret_cast<const char*>(binary_message);
+
+  return std::make_unique<std::string>(raw_message, message_size);
+}
+
+}  // namespace flutter

--- a/src/flutter/shell/platform/linux_embedded/plugins/lifecycle_plugin.cc
+++ b/src/flutter/shell/platform/linux_embedded/plugins/lifecycle_plugin.cc
@@ -4,7 +4,7 @@
 
 #include "flutter/shell/platform/linux_embedded/plugins/lifecycle_plugin.h"
 
-#include "flutter/shell/platform/common/client_wrapper/include/flutter/standard_message_codec.h"
+#include "flutter/shell/platform/common/client_wrapper/include/flutter/string_message_codec.h"
 #include "flutter/shell/platform/linux_embedded/logger.h"
 
 namespace flutter {
@@ -18,29 +18,29 @@ constexpr char kDetached[] = "AppLifecycleState.detached";
 }  // namespace
 
 LifecyclePlugin::LifecyclePlugin(BinaryMessenger* messenger)
-    : channel_(std::make_unique<BasicMessageChannel<EncodableValue>>(
+    : channel_(std::make_unique<BasicMessageChannel<std::string>>(
           messenger,
           kChannelName,
-          &StandardMessageCodec::GetInstance())) {}
+          &StringMessageCodec::GetInstance())) {}
 
 void LifecyclePlugin::OnInactive() const {
   ELINUX_LOG(DEBUG) << "App lifecycle changed to inactive state.";
-  channel_->Send(EncodableValue(std::string(kInactive)));
+  channel_->Send(std::string(kInactive));
 }
 
 void LifecyclePlugin::OnResumed() const {
   ELINUX_LOG(DEBUG) << "App lifecycle changed to resumed state.";
-  channel_->Send(EncodableValue(std::string(kResumed)));
+  channel_->Send(std::string(kResumed));
 }
 
 void LifecyclePlugin::OnPaused() const {
   ELINUX_LOG(DEBUG) << "App lifecycle changed to paused state.";
-  channel_->Send(EncodableValue(std::string(kPaused)));
+  channel_->Send(std::string(kPaused));
 }
 
 void LifecyclePlugin::OnDetached() const {
   ELINUX_LOG(DEBUG) << "App lifecycle changed to detached state.";
-  channel_->Send(EncodableValue(std::string(kDetached)));
+  channel_->Send(std::string(kDetached));
 }
 
 }  // namespace flutter

--- a/src/flutter/shell/platform/linux_embedded/plugins/lifecycle_plugin.h
+++ b/src/flutter/shell/platform/linux_embedded/plugins/lifecycle_plugin.h
@@ -26,7 +26,7 @@ class LifecyclePlugin {
   void OnDetached() const;
 
  private:
-  std::unique_ptr<flutter::BasicMessageChannel<EncodableValue>> channel_;
+  std::unique_ptr<flutter::BasicMessageChannel<std::string>> channel_;
 };
 
 }  // namespace flutter


### PR DESCRIPTION
The lifecycle plugin was using a *standard* message codec but it is supposed to be using a *string* message codec.

I haven't found any official documentation about why that's the case  (except for [these](https://github.com/flutter/engine/blob/8f2221fbef28b478debb78dd233f5250b220ca99/shell/platform/darwin/common/framework/Headers/FlutterCodecs.h#L58-L60) code [comments](https://github.com/flutter/engine/blob/8f2221fbef28b478debb78dd233f5250b220ca99/shell/platform/android/io/flutter/plugin/common/StringCodec.java#L14-L16)) but that's how it is currently implemented for both [iOS](https://github.com/flutter/engine/blob/8f2221fbef28b478debb78dd233f5250b220ca99/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm#L572) and [Android](https://github.com/flutter/engine/blob/8f2221fbef28b478debb78dd233f5250b220ca99/shell/platform/android/io/flutter/embedding/engine/systemchannels/LifecycleChannel.java#L21).

Without this change, [neither the engine](https://github.com/flutter/engine/blob/8f2221fbef28b478debb78dd233f5250b220ca99/shell/common/engine.cc#L320-L321) nor the dart side were able to *correctly* decode the lifecycle messages.

This pull-request fixes that by adding a `StringMessageCodec` implementation and replacing the `StandardMessageCodec` with it in the lifecycle plugin.

PS: I'm okay with delegating all rights related to this change to Sony.
