### PR TITLE
Redraw cursor when re-entering window

### DIFF
--- a/src/flutter/shell/platform/linux_embedded/window/elinux_window_wayland.cc
+++ b/src/flutter/shell/platform/linux_embedded/window/elinux_window_wayland.cc
@@ -282,6 +282,12 @@ const wl_pointer_listener ELinuxWindowWayland::kWlPointerListener = {
       self->wl_current_surface_ = surface;
       self->serial_ = serial;
 
+      if (self->view_properties_.use_mouse_cursor) {
+        // Clear the cursor name in order to make sure it gets redrawn next time
+        // it enters the surface.
+        self->cursor_info_.cursor_name.clear();
+      }
+
       if (self->binding_handler_delegate_) {
         self->binding_handler_delegate_->OnPointerLeave();
         self->pointer_x_ = -1;


### PR DESCRIPTION
Clear the current cursor name when leaving the window in order to make sure it gets redrawn the next time it enters the window.

This is necessary due to this bit of logic which skips drawing the cursor if it hasn't changed since the last time it was drawn:

https://github.com/sony/flutter-embedded-linux/blob/df0d3fc545b7656e3c0242c23dc4bb3d29c30ea3/src/flutter/shell/platform/linux_embedded/window/elinux_window_wayland.cc#L1201-L1203

### Comparison videos (before and after)

https://user-images.githubusercontent.com/433598/208247802-5eaeeab6-8e9f-42dd-b4d9-45a49cb2bdc6.mp4

https://user-images.githubusercontent.com/433598/208247811-149f2c6e-683e-489d-8a09-cd4d0116e54b.mp4

**Note**: I agree to delegate all rights related to this PR to Sony.