### PR TITLE
Use positive height for button resize argument

### DIFF
--- a/src/flutter/shell/platform/linux_embedded/window/renderer/window_decorations_wayland.cc
+++ b/src/flutter/shell/platform/linux_embedded/window/renderer/window_decorations_wayland.cc
@@ -95,7 +95,7 @@ void WindowDecorationsWayland::Resize(const int32_t width,
     buttons_[i]->SetPosition(
         width - kButtonWidth * (i + 1) - kButtonMargin * (i + 1),
         -(kButtonHeight + (kTitleBarHeight - kButtonHeight) / 2));
-    buttons_[i]->Resize(kButtonWidth, -kButtonHeight);
+    buttons_[i]->Resize(kButtonWidth, kButtonHeight);
   }
 }
 


### PR DESCRIPTION
Fix small typo which was causing a negative height value to be passed to the button resize method.

**Note**: I agree to delegate all rights related to this PR to Sony.