### PR TITLE
Continue listening for presentation feedback events after discarded frame

### DIFF
--- a/src/flutter/shell/platform/linux_embedded/window/elinux_window_wayland.cc
+++ b/src/flutter/shell/platform/linux_embedded/window/elinux_window_wayland.cc
@@ -226,7 +226,18 @@ const wp_presentation_feedback_listener
             },
         .discarded =
             [](void* data,
-               struct wp_presentation_feedback* wp_presentation_feedback) {},
+               struct wp_presentation_feedback* wp_presentation_feedback) {
+              auto self = reinterpret_cast<ELinuxWindowWayland*>(data);
+
+              if (self->window_decorations_) {
+                self->window_decorations_->Draw();
+              }
+
+              wp_presentation_feedback_add_listener(
+                  ::wp_presentation_feedback(self->wp_presentation_,
+                                             self->native_window_->Surface()),
+                  &kWpPresentationFeedbackListener, data);
+            },
 };
 
 const wl_callback_listener ELinuxWindowWayland::kWlSurfaceFrameListener = {


### PR DESCRIPTION
The previous code stopped listening for presentation feedback events as soon as a discarded event was received.

When this happened, the client-side decorations stopped being redrawn and got "stuck". This broken state could be consistently reproduced on sway when resizing the window using $mod key + mouse right click (see screen recordings below).

[before.webm](https://user-images.githubusercontent.com/433598/209867850-54b1823a-ae51-4d15-b081-af767e7598ae.webm)

[after.webm](https://user-images.githubusercontent.com/433598/209867875-0616b0a3-3c2a-467b-bca5-5ba2b5812ec6.webm)

This pull-request fixes that by continuing to listen to presentation feedback events after `discarded` events.

**Note**: I agree to delegate all rights related to this PR to Sony.