### PR TITLE
Fix cursor hotspot for scale factors different than 1

### DIFF
--- a/src/flutter/shell/platform/linux_embedded/window/elinux_window_wayland.cc
+++ b/src/flutter/shell/platform/linux_embedded/window/elinux_window_wayland.cc
@@ -1274,9 +1274,9 @@ void ELinuxWindowWayland::UpdateFlutterCursor(const std::string& cursor_name) {
     auto image = wl_cursor->images[0];
     auto buffer = wl_cursor_image_get_buffer(image);
     if (buffer) {
-      wl_pointer_set_cursor(cursor_info_.pointer, cursor_info_.serial,
-                            wl_cursor_surface_, image->hotspot_x,
-                            image->hotspot_y);
+      wl_pointer_set_cursor(
+          cursor_info_.pointer, cursor_info_.serial, wl_cursor_surface_,
+          image->hotspot_x / current_scale_, image->hotspot_y / current_scale_);
       wl_surface_attach(wl_cursor_surface_, buffer, 0, 0);
       wl_surface_damage(wl_cursor_surface_, 0, 0, image->width, image->height);
       wl_surface_set_buffer_scale(wl_cursor_surface_, current_scale_);


### PR DESCRIPTION
The previous logic contained a bug related to the cursor hotspot coordinates which made the cursor "jump" around when entering and leaving the window surface (see screen recordings below).

[before.webm](https://user-images.githubusercontent.com/433598/209983736-cd33733b-a84d-4b66-b412-ed286afebbd0.webm)

[after.webm](https://user-images.githubusercontent.com/433598/209983730-2d1632cc-656c-446d-b6cb-1d93e99edc42.webm)


This pull-request fixes that by dividing the hotspot by the scaling factor.

**Note**: I agree to delegate all rights related to this PR to Sony.