### PR TITLE
Subtract client decorations height from flutter surface height

### DIFF
--- a/src/flutter/shell/platform/linux_embedded/window/elinux_window_wayland.cc
+++ b/src/flutter/shell/platform/linux_embedded/window/elinux_window_wayland.cc
@@ -138,8 +138,9 @@ const xdg_toplevel_listener ELinuxWindowWayland::kXdgToplevelListener = {
             self->window_decorations_->Resize(next_width, next_height);
           }
           if (self->binding_handler_delegate_) {
-            self->binding_handler_delegate_->OnWindowSizeChanged(next_width,
-                                                                 next_height);
+            self->binding_handler_delegate_->OnWindowSizeChanged(
+                next_width,
+                next_height - self->WindowDecorationsPhysicalHeight());
           }
         },
     .close =
@@ -1604,8 +1605,17 @@ void ELinuxWindowWayland::UpdateWindowScale() {
 
   if (this->binding_handler_delegate_) {
     this->binding_handler_delegate_->OnWindowSizeChanged(
-        this->view_properties_.width, this->view_properties_.height);
+        this->view_properties_.width,
+        this->view_properties_.height -
+            this->WindowDecorationsPhysicalHeight());
   }
+}
+
+uint32_t ELinuxWindowWayland::WindowDecorationsPhysicalHeight() const {
+  if (!this->window_decorations_)
+    return 0;
+
+  return this->window_decorations_->Height() * current_scale_;
 }
 
 }  // namespace flutter

--- a/src/flutter/shell/platform/linux_embedded/window/elinux_window_wayland.h
+++ b/src/flutter/shell/platform/linux_embedded/window/elinux_window_wayland.h
@@ -105,6 +105,9 @@ class ELinuxWindowWayland : public ELinuxWindow, public WindowBindingHandler {
   // Updates the surface scale of the window from the list of entered outputs.
   void UpdateWindowScale();
 
+  // Get window decorations height in physical pixels.
+  uint32_t WindowDecorationsPhysicalHeight() const;
+
   static const wl_registry_listener kWlRegistryListener;
   static const xdg_wm_base_listener kXdgWmBaseListener;
   static const xdg_surface_listener kXdgSurfaceListener;


### PR DESCRIPTION
When client decorations are enabled the Flutter surface size should be equal to window height minus the client decorations height.

Without this change the content at the bottom of the Flutter surface could get "cropped" when client decorations are enabled.

**Note**: I agree to delegate all rights related to this PR to Sony.