### PR TITLE
Annotate code with coordinate system information

### DIFF
--- a/src/flutter/shell/platform/linux_embedded/flutter_elinux_view.h
+++ b/src/flutter/shell/platform/linux_embedded/flutter_elinux_view.h
@@ -82,19 +82,19 @@ class FlutterELinuxView : public WindowBindingHandlerDelegate {
   void SendInitialBounds();
 
   // |WindowBindingHandlerDelegate|
-  void OnWindowSizeChanged(size_t width, size_t height) const override;
+  void OnWindowSizeChanged(size_t width_px, size_t height_px) const override;
 
   // |WindowBindingHandlerDelegate|
-  void OnPointerMove(double x, double y) override;
+  void OnPointerMove(double x_px, double y_px) override;
 
   // |WindowBindingHandlerDelegate|
-  void OnPointerDown(double x,
-                     double y,
+  void OnPointerDown(double x_px,
+                     double y_px,
                      FlutterPointerMouseButtons button) override;
 
   // |WindowBindingHandlerDelegate|
-  void OnPointerUp(double x,
-                   double y,
+  void OnPointerUp(double x_px,
+                   double y_px,
                    FlutterPointerMouseButtons button) override;
 
   // |WindowBindingHandlerDelegate|
@@ -188,17 +188,27 @@ class FlutterELinuxView : public WindowBindingHandlerDelegate {
   touch_point* GgeTouchPoint(int32_t id);
 
   // Sends a window metrics update to the Flutter engine using current window
-  // dimensions in physical
-  void SendWindowMetrics(size_t width, size_t height, double dpiscale) const;
+  // dimensions in physical pixels.
+  // @param[in] width_px       Physical width of the window.
+  // @param[in] height_px      Physical height of the window.
+  void SendWindowMetrics(size_t width_px,
+                         size_t height_px,
+                         double dpiscale) const;
 
   // Reports a mouse movement to Flutter engine.
-  void SendPointerMove(double x, double y);
+  // @param[in] x_px The x coordinate of the pointer event in physical pixels.
+  // @param[in] y_px The y coordinate of the pointer event in physical pixels.
+  void SendPointerMove(double x_px, double y_px);
 
   // Reports mouse press to Flutter engine.
-  void SendPointerDown(double x, double y);
+  // @param[in] x_px The x coordinate of the pointer event in physical pixels.
+  // @param[in] y_px The y coordinate of the pointer event in physical pixels.
+  void SendPointerDown(double x_px, double y_px);
 
   // Reports mouse release to Flutter engine.
-  void SendPointerUp(double x, double y);
+  // @param[in] x_px The x coordinate of the pointer event in physical pixels.
+  // @param[in] y_px The y coordinate of the pointer event in physical pixels.
+  void SendPointerUp(double x_px, double y_px);
 
   // Reports mouse left the window client area.
   //
@@ -243,7 +253,9 @@ class FlutterELinuxView : public WindowBindingHandlerDelegate {
   void SetMouseButtons(uint64_t buttons) { mouse_state_.buttons = buttons; }
 
   // Returns a trimmed pointer of user inputs with the window rotation.
-  std::pair<double, double> GetPointerRotation(double x, double y);
+  // @param[in] x_px The x coordinate of the pointer event in physical pixels.
+  // @param[in] y_px The y coordinate of the pointer event in physical pixels.
+  std::pair<double, double> GetPointerRotation(double x_px, double y_px);
 
   // The engine associated with this view.
   std::unique_ptr<FlutterELinuxEngine> engine_;

--- a/src/flutter/shell/platform/linux_embedded/surface/surface_base.cc
+++ b/src/flutter/shell/platform/linux_embedded/surface/surface_base.cc
@@ -29,9 +29,9 @@ bool SurfaceBase::SetNativeWindow(NativeWindow* window) {
   return true;
 };
 
-bool SurfaceBase::OnScreenSurfaceResize(const size_t width,
-                                        const size_t height) {
-  if (!native_window_->Resize(width, height)) {
+bool SurfaceBase::OnScreenSurfaceResize(const size_t width_px,
+                                        const size_t height_px) {
+  if (!native_window_->Resize(width_px, height_px)) {
     ELINUX_LOG(ERROR) << "Failed to resize.";
     return false;
   }

--- a/src/flutter/shell/platform/linux_embedded/surface/surface_base.h
+++ b/src/flutter/shell/platform/linux_embedded/surface/surface_base.h
@@ -28,7 +28,9 @@ class SurfaceBase {
   // On-screen surface needs to be recreated after window size changed only when
   // using DRM-GBM backend. Because gbm-surface is recreated when the window
   // size changed.
-  bool OnScreenSurfaceResize(const size_t width, const size_t height);
+  // @param[in] width_px       Physical width of the surface.
+  // @param[in] height_px      Physical height of the surface.
+  bool OnScreenSurfaceResize(const size_t width_px, const size_t height_px);
 
   // Clears current on-screen context.
   bool ClearCurrentContext() const;

--- a/src/flutter/shell/platform/linux_embedded/surface/surface_decoration.cc
+++ b/src/flutter/shell/platform/linux_embedded/surface/surface_decoration.cc
@@ -27,8 +27,8 @@ bool SurfaceDecoration::SetNativeWindow(NativeWindow* window) {
   return true;
 };
 
-bool SurfaceDecoration::Resize(const size_t width, const size_t height) {
-  if (!native_window_->Resize(width, height)) {
+bool SurfaceDecoration::Resize(const size_t width_px, const size_t height_px) {
+  if (!native_window_->Resize(width_px, height_px)) {
     ELINUX_LOG(ERROR) << "Failed to resize.";
     return false;
   }

--- a/src/flutter/shell/platform/linux_embedded/surface/surface_decoration.h
+++ b/src/flutter/shell/platform/linux_embedded/surface/surface_decoration.h
@@ -26,8 +26,10 @@ class SurfaceDecoration : public SurfaceGlDelegate {
   // Sets a netive platform's window.
   bool SetNativeWindow(NativeWindow* window);
 
-  // Changes an decoration surface size.
-  bool Resize(const size_t width, const size_t height);
+  // Changes a decoration surface size.
+  // @param[in] width_px       Physical width of the surface.
+  // @param[in] height_px      Physical height of the surface.
+  bool Resize(const size_t width_px, const size_t height_px);
 
   // Clears and destroys current decoration context.
   void DestroyContext();

--- a/src/flutter/shell/platform/linux_embedded/window/elinux_window.h
+++ b/src/flutter/shell/platform/linux_embedded/window/elinux_window.h
@@ -17,8 +17,10 @@ class ELinuxWindow {
  protected:
   virtual bool IsValid() const = 0;
 
+  // Get current window width in physical pixels.
   uint32_t GetCurrentWidth() const { return view_properties_.width; }
 
+  // Get current window height in physical pixels.
   uint32_t GetCurrentHeight() const { return view_properties_.height; }
 
   void SetRotation(FlutterDesktopViewRotation rotation) {
@@ -36,7 +38,9 @@ class ELinuxWindow {
   FlutterDesktopViewProperties view_properties_;
   double current_scale_ = 1.0;
   uint16_t current_rotation_ = 0;
+  // The x coordinate of the pointer in physical pixels.
   double pointer_x_ = 0;
+  // The y coordinate of the pointer in physical pixels.
   double pointer_y_ = 0;
   std::string clipboard_data_ = "";
 };

--- a/src/flutter/shell/platform/linux_embedded/window/elinux_window_wayland.cc
+++ b/src/flutter/shell/platform/linux_embedded/window/elinux_window_wayland.cc
@@ -1139,7 +1139,8 @@ bool ELinuxWindowWayland::DispatchEvent() {
   return true;
 }
 
-bool ELinuxWindowWayland::CreateRenderSurface(int32_t width, int32_t height) {
+bool ELinuxWindowWayland::CreateRenderSurface(int32_t width_px,
+                                              int32_t height_px) {
   if (!display_valid_) {
     ELINUX_LOG(ERROR) << "Wayland display is invalid.";
     return false;
@@ -1156,12 +1157,12 @@ bool ELinuxWindowWayland::CreateRenderSurface(int32_t width, int32_t height) {
   }
 
   if (view_properties_.view_mode == FlutterDesktopViewMode::kFullscreen) {
-    width = view_properties_.width;
-    height = view_properties_.height;
+    width_px = view_properties_.width;
+    height_px = view_properties_.height;
   }
 
-  ELINUX_LOG(TRACE) << "Created the Wayland surface: " << width << "x"
-                    << height;
+  ELINUX_LOG(TRACE) << "Created the Wayland surface: " << width_px << "x"
+                    << height_px;
   if (view_properties_.use_mouse_cursor) {
     wl_cursor_surface_ = wl_compositor_create_surface(wl_compositor_);
     if (!wl_cursor_surface_) {
@@ -1172,10 +1173,10 @@ bool ELinuxWindowWayland::CreateRenderSurface(int32_t width, int32_t height) {
   }
 
   if (current_rotation_ == 90 || current_rotation_ == 270) {
-    std::swap(width, height);
+    std::swap(width_px, height_px);
   }
-  native_window_ =
-      std::make_unique<NativeWindowWayland>(wl_compositor_, width, height);
+  native_window_ = std::make_unique<NativeWindowWayland>(wl_compositor_,
+                                                         width_px, height_px);
 
   wl_surface_add_listener(native_window_->Surface(), &kWlSurfaceListener, this);
 
@@ -1211,7 +1212,7 @@ bool ELinuxWindowWayland::CreateRenderSurface(int32_t width, int32_t height) {
   if (view_properties_.use_window_decoration) {
     window_decorations_ = std::make_unique<WindowDecorationsWayland>(
         wl_display_, wl_compositor_, wl_subcompositor_,
-        native_window_->Surface(), width, height);
+        native_window_->Surface(), width_px, height_px);
   }
 
   return true;

--- a/src/flutter/shell/platform/linux_embedded/window/elinux_window_wayland.h
+++ b/src/flutter/shell/platform/linux_embedded/window/elinux_window_wayland.h
@@ -45,7 +45,7 @@ class ELinuxWindowWayland : public ELinuxWindow, public WindowBindingHandler {
   bool DispatchEvent() override;
 
   // |FlutterWindowBindingHandler|
-  bool CreateRenderSurface(int32_t width, int32_t height) override;
+  bool CreateRenderSurface(int32_t width_px, int32_t height_px) override;
 
   // |FlutterWindowBindingHandler|
   void DestroyRenderSurface() override;

--- a/src/flutter/shell/platform/linux_embedded/window/native_window.h
+++ b/src/flutter/shell/platform/linux_embedded/window/native_window.h
@@ -21,6 +21,7 @@ class NativeWindow {
   // Gets a window (GBM surface) for offscreen resource.
   EGLNativeWindowType WindowOffscreen() const { return window_offscreen_; }
 
+  // Get physical width of the window.
   int32_t Width() const {
     if (!valid_) {
       return -1;
@@ -28,6 +29,7 @@ class NativeWindow {
     return width_;
   }
 
+  // Get physical height of the window.
   int32_t Height() const {
     if (!valid_) {
       return -1;
@@ -39,12 +41,16 @@ class NativeWindow {
 
   // Sets a window position. Basically, this API is used for window decorations
   // such as titlebar.
-  virtual void SetPosition(const int32_t x, const int32_t y) {
-    x_ = x;
-    y_ = y;
+  // @param[in] x_dip   The x coordinate in logical pixels.
+  // @param[in] y_dip   The y coordinate in logical pixels.
+  virtual void SetPosition(const int32_t x_dip, const int32_t y_dip) {
+    x_ = x_dip;
+    y_ = y_dip;
   };
 
-  virtual bool Resize(const size_t width, const size_t height) = 0;
+  // @param[in] width_px       Physical width of the window.
+  // @param[in] height_px      Physical height of the window.
+  virtual bool Resize(const size_t width_px, const size_t height_px) = 0;
 
   // Swaps frame buffers. This API performs processing only for the DRM-GBM
   // backend. It is prepared to make the interface common.
@@ -53,9 +59,13 @@ class NativeWindow {
  protected:
   EGLNativeWindowType window_;
   EGLNativeWindowType window_offscreen_;
+  // Physical width of the window.
   int32_t width_;
+  // Physical height of the window.
   int32_t height_;
+  // The x coordinate of the window in logical pixels.
   int32_t x_;
+  // The y coordinate of the window in logical pixels.
   int32_t y_;
   bool valid_ = false;
 };

--- a/src/flutter/shell/platform/linux_embedded/window/native_window_wayland.cc
+++ b/src/flutter/shell/platform/linux_embedded/window/native_window_wayland.cc
@@ -9,15 +9,15 @@
 namespace flutter {
 
 NativeWindowWayland::NativeWindowWayland(wl_compositor* compositor,
-                                         const size_t width,
-                                         const size_t height) {
+                                         const size_t width_px,
+                                         const size_t height_px) {
   surface_ = wl_compositor_create_surface(compositor);
   if (!surface_) {
     ELINUX_LOG(ERROR) << "Failed to create the compositor surface.";
     return;
   }
 
-  window_ = wl_egl_window_create(surface_, width, height);
+  window_ = wl_egl_window_create(surface_, width_px, height_px);
   if (!window_) {
     ELINUX_LOG(ERROR) << "Failed to create the EGL window.";
     return;
@@ -40,8 +40,8 @@ NativeWindowWayland::NativeWindowWayland(wl_compositor* compositor,
     }
   }
 
-  width_ = width;
-  height_ = height;
+  width_ = width_px;
+  height_ = height_px;
   valid_ = true;
 }
 
@@ -67,15 +67,16 @@ NativeWindowWayland::~NativeWindowWayland() {
   }
 }
 
-bool NativeWindowWayland::Resize(const size_t width, const size_t height) {
+bool NativeWindowWayland::Resize(const size_t width_px,
+                                 const size_t height_px) {
   if (!valid_) {
     ELINUX_LOG(ERROR) << "Failed to resize the window.";
     return false;
   }
-  wl_egl_window_resize(window_, width, height, 0, 0);
+  wl_egl_window_resize(window_, width_px, height_px, 0, 0);
 
-  width_ = width;
-  height_ = height;
+  width_ = width_px;
+  height_ = height_px;
   return true;
 }
 

--- a/src/flutter/shell/platform/linux_embedded/window/native_window_wayland.h
+++ b/src/flutter/shell/platform/linux_embedded/window/native_window_wayland.h
@@ -13,13 +13,15 @@ namespace flutter {
 
 class NativeWindowWayland : public NativeWindow {
  public:
+  // @param[in] width_px       Physical width of the window.
+  // @param[in] height_px      Physical height of the window.
   NativeWindowWayland(wl_compositor* compositor,
-                      const size_t width,
-                      const size_t height);
+                      const size_t width_px,
+                      const size_t height_px);
   ~NativeWindowWayland();
 
   // |NativeWindow|
-  bool Resize(const size_t width, const size_t height) override;
+  bool Resize(const size_t width_px, const size_t height_px) override;
 
   wl_surface* Surface() const { return surface_; }
 

--- a/src/flutter/shell/platform/linux_embedded/window/native_window_wayland_decoration.cc
+++ b/src/flutter/shell/platform/linux_embedded/window/native_window_wayland_decoration.cc
@@ -12,8 +12,8 @@ NativeWindowWaylandDecoration::NativeWindowWaylandDecoration(
     wl_compositor* compositor,
     wl_subcompositor* subcompositor,
     wl_surface* parent_surface,
-    const size_t width,
-    const size_t height) {
+    const size_t width_px,
+    const size_t height_px) {
   surface_ = wl_compositor_create_surface(compositor);
   if (!surface_) {
     ELINUX_LOG(ERROR) << "Failed to create the compositor surface.";
@@ -35,8 +35,8 @@ NativeWindowWaylandDecoration::NativeWindowWaylandDecoration(
     return;
   }
 
-  width_ = width;
-  height_ = height;
+  width_ = width_px;
+  height_ = height_px;
   valid_ = true;
 }
 
@@ -52,29 +52,29 @@ NativeWindowWaylandDecoration::~NativeWindowWaylandDecoration() {
   }
 }
 
-bool NativeWindowWaylandDecoration::Resize(const size_t width,
-                                           const size_t height) {
+bool NativeWindowWaylandDecoration::Resize(const size_t width_px,
+                                           const size_t height_px) {
   if (!valid_) {
     ELINUX_LOG(ERROR) << "Failed to resize the window.";
     return false;
   }
 
-  width_ = width;
-  height_ = height;
-  wl_egl_window_resize(window_, width, height, 0, 0);
+  width_ = width_px;
+  height_ = height_px;
+  wl_egl_window_resize(window_, width_px, height_px, 0, 0);
   return true;
 }
 
-void NativeWindowWaylandDecoration::SetPosition(const int32_t x,
-                                                const int32_t y) {
+void NativeWindowWaylandDecoration::SetPosition(const int32_t x_dip,
+                                                const int32_t y_dip) {
   if (!valid_) {
     ELINUX_LOG(ERROR) << "Failed to set the position of the window.";
     return;
   }
 
-  x_ = x;
-  y_ = y;
-  wl_subsurface_set_position(subsurface_, x, y);
+  x_ = x_dip;
+  y_ = y_dip;
+  wl_subsurface_set_position(subsurface_, x_dip, y_dip);
 }
 
 }  // namespace flutter

--- a/src/flutter/shell/platform/linux_embedded/window/native_window_wayland_decoration.h
+++ b/src/flutter/shell/platform/linux_embedded/window/native_window_wayland_decoration.h
@@ -14,18 +14,20 @@ namespace flutter {
 
 class NativeWindowWaylandDecoration : public NativeWindow {
  public:
+  // @param[in] width_px       Physical width of the window.
+  // @param[in] height_px      Physical height of the window.
   NativeWindowWaylandDecoration(wl_compositor* compositor,
                                 wl_subcompositor* subcompositor,
                                 wl_surface* parent_surface,
-                                const size_t width,
-                                const size_t height);
+                                const size_t width_px,
+                                const size_t height_px);
   ~NativeWindowWaylandDecoration();
 
   // |NativeWindow|
-  bool Resize(const size_t width, const size_t height) override;
+  bool Resize(const size_t width_px, const size_t height_px) override;
 
   // |NativeWindow|
-  void SetPosition(const int32_t x, const int32_t y) override;
+  void SetPosition(const int32_t x_dip, const int32_t y_dip) override;
 
   wl_surface* Surface() const { return surface_; }
 

--- a/src/flutter/shell/platform/linux_embedded/window/renderer/window_decoration.h
+++ b/src/flutter/shell/platform/linux_embedded/window/renderer/window_decoration.h
@@ -28,9 +28,13 @@ class WindowDecoration {
 
   virtual void Draw() = 0;
 
-  virtual void SetPosition(const int32_t x, const int32_t y) = 0;
+  // @param[in] x_dip          The x coordinate in logical pixels.
+  // @param[in] y_dip          The y coordinate in logical pixels.
+  virtual void SetPosition(const int32_t x_dip, const int32_t y_dip) = 0;
 
-  virtual void Resize(const int32_t width, const int32_t height) = 0;
+  // @param[in] width_px   Physical width of the window.
+  // @param[in] height_px  Physical height of the window.
+  virtual void Resize(const size_t width_px, const size_t height_px) = 0;
 
   void DestroyContext() const { render_surface_->DestroyContext(); };
 

--- a/src/flutter/shell/platform/linux_embedded/window/renderer/window_decoration_button.cc
+++ b/src/flutter/shell/platform/linux_embedded/window/renderer/window_decoration_button.cc
@@ -198,12 +198,14 @@ void WindowDecorationButton::Draw() {
   render_surface_->GLContextPresent(0);
 }
 
-void WindowDecorationButton::SetPosition(const int32_t x, const int32_t y) {
-  native_window_->SetPosition(x, y);
+void WindowDecorationButton::SetPosition(const int32_t x_dip,
+                                         const int32_t y_dip) {
+  native_window_->SetPosition(x_dip, y_dip);
 }
 
-void WindowDecorationButton::Resize(const int32_t width, const int32_t height) {
-  render_surface_->Resize(width, height);
+void WindowDecorationButton::Resize(const size_t width_px,
+                                    const size_t height_px) {
+  render_surface_->Resize(width_px, height_px);
 }
 
 void WindowDecorationButton::LoadShader() {

--- a/src/flutter/shell/platform/linux_embedded/window/renderer/window_decoration_button.h
+++ b/src/flutter/shell/platform/linux_embedded/window/renderer/window_decoration_button.h
@@ -21,10 +21,10 @@ class WindowDecorationButton : public WindowDecoration {
   void Draw() override;
 
   // |WindowDecoration|
-  void SetPosition(const int32_t x, const int32_t y) override;
+  void SetPosition(const int32_t x_dip, const int32_t y_dip) override;
 
   // |WindowDecoration|
-  void Resize(const int32_t width, const int32_t height) override;
+  void Resize(const size_t width_px, const size_t height_px) override;
 
  private:
   void LoadShader();

--- a/src/flutter/shell/platform/linux_embedded/window/renderer/window_decoration_titlebar.cc
+++ b/src/flutter/shell/platform/linux_embedded/window/renderer/window_decoration_titlebar.cc
@@ -69,13 +69,14 @@ void WindowDecorationTitlebar::Draw() {
   render_surface_->GLContextPresent(0);
 }
 
-void WindowDecorationTitlebar::SetPosition(const int32_t x, const int32_t y) {
-  native_window_->SetPosition(x, y);
+void WindowDecorationTitlebar::SetPosition(const int32_t x_dip,
+                                           const int32_t y_dip) {
+  native_window_->SetPosition(x_dip, y_dip);
 }
 
-void WindowDecorationTitlebar::Resize(const int32_t width,
-                                      const int32_t height) {
-  render_surface_->Resize(width, height);
+void WindowDecorationTitlebar::Resize(const size_t width_px,
+                                      const size_t height_px) {
+  render_surface_->Resize(width_px, height_px);
 }
 
 }  // namespace flutter

--- a/src/flutter/shell/platform/linux_embedded/window/renderer/window_decoration_titlebar.h
+++ b/src/flutter/shell/platform/linux_embedded/window/renderer/window_decoration_titlebar.h
@@ -19,10 +19,10 @@ class WindowDecorationTitlebar : public WindowDecoration {
   void Draw() override;
 
   // |WindowDecoration|
-  void SetPosition(const int32_t x, const int32_t y) override;
+  void SetPosition(const int32_t x_dip, const int32_t y_dip) override;
 
   // |WindowDecoration|
-  void Resize(const int32_t width, const int32_t height) override;
+  void Resize(const size_t width_px, const size_t height_px) override;
 };
 
 }  // namespace flutter

--- a/src/flutter/shell/platform/linux_embedded/window/renderer/window_decorations_wayland.cc
+++ b/src/flutter/shell/platform/linux_embedded/window/renderer/window_decorations_wayland.cc
@@ -10,11 +10,11 @@
 namespace flutter {
 
 namespace {
-constexpr uint kTitleBarHeight = 30;
+constexpr uint kTitleBarHeightDIP = 30;
 
-constexpr uint kButtonWidth = 15;
-constexpr uint kButtonHeight = 15;
-constexpr uint kButtonMargin = 10;
+constexpr uint kButtonWidthDIP = 15;
+constexpr uint kButtonHeightDIP = 15;
+constexpr uint kButtonMarginDIP = 10;
 }  // namespace
 
 WindowDecorationsWayland::WindowDecorationsWayland(
@@ -22,53 +22,57 @@ WindowDecorationsWayland::WindowDecorationsWayland(
     wl_compositor* compositor,
     wl_subcompositor* subcompositor,
     wl_surface* root_surface,
-    int32_t width,
-    int32_t height) {
+    int32_t width_dip,
+    int32_t height_dip) {
   constexpr bool sub_egl_display = true;
 
   // title-bar.
   titlebar_ = std::make_unique<WindowDecorationTitlebar>(
-      std::make_unique<NativeWindowWaylandDecoration>(
-          compositor, subcompositor, root_surface, width, kTitleBarHeight),
+      std::make_unique<NativeWindowWaylandDecoration>(compositor, subcompositor,
+                                                      root_surface, width_dip,
+                                                      kTitleBarHeightDIP),
       std::make_unique<SurfaceDecoration>(std::make_unique<ContextEgl>(
           std::make_unique<EnvironmentEgl>(display, sub_egl_display))));
-  titlebar_->SetPosition(0, -kTitleBarHeight);
+  titlebar_->SetPosition(0, -kTitleBarHeightDIP);
 
   // close button.
   auto type = WindowDecorationButton::DecorationType::CLOSE_BUTTON;
   buttons_.push_back(std::make_unique<WindowDecorationButton>(
       type,
       std::make_unique<NativeWindowWaylandDecoration>(
-          compositor, subcompositor, root_surface, kButtonWidth, kButtonHeight),
+          compositor, subcompositor, root_surface, kButtonWidthDIP,
+          kButtonHeightDIP),
       std::make_unique<SurfaceDecoration>(std::make_unique<ContextEgl>(
           std::make_unique<EnvironmentEgl>(display, sub_egl_display)))));
   buttons_[type]->SetPosition(
-      width - kButtonWidth - kButtonMargin,
-      -(kButtonHeight + (kTitleBarHeight - kButtonHeight) / 2));
+      width_dip - kButtonWidthDIP - kButtonMarginDIP,
+      -(kButtonHeightDIP + (kTitleBarHeightDIP - kButtonHeightDIP) / 2));
 
   // maximise button.
   type = WindowDecorationButton::DecorationType::MAXIMISE_BUTTON;
   buttons_.push_back(std::make_unique<WindowDecorationButton>(
       type,
       std::make_unique<NativeWindowWaylandDecoration>(
-          compositor, subcompositor, root_surface, kButtonWidth, kButtonHeight),
+          compositor, subcompositor, root_surface, kButtonWidthDIP,
+          kButtonHeightDIP),
       std::make_unique<SurfaceDecoration>(std::make_unique<ContextEgl>(
           std::make_unique<EnvironmentEgl>(display, sub_egl_display)))));
   buttons_[type]->SetPosition(
-      width - kButtonWidth * 2 - kButtonMargin * 2,
-      -(kButtonHeight + (kTitleBarHeight - kButtonHeight) / 2));
+      width_dip - kButtonWidthDIP * 2 - kButtonMarginDIP * 2,
+      -(kButtonHeightDIP + (kTitleBarHeightDIP - kButtonHeightDIP) / 2));
 
   // minimise button.
   type = WindowDecorationButton::DecorationType::MINIMISE_BUTTON;
   buttons_.push_back(std::make_unique<WindowDecorationButton>(
       type,
       std::make_unique<NativeWindowWaylandDecoration>(
-          compositor, subcompositor, root_surface, kButtonWidth, kButtonHeight),
+          compositor, subcompositor, root_surface, kButtonWidthDIP,
+          kButtonHeightDIP),
       std::make_unique<SurfaceDecoration>(std::make_unique<ContextEgl>(
           std::make_unique<EnvironmentEgl>(display, sub_egl_display)))));
   buttons_[type]->SetPosition(
-      width - kButtonWidth * 3 - kButtonMargin * 3,
-      -(kButtonHeight + (kTitleBarHeight - kButtonHeight) / 2));
+      width_dip - kButtonWidthDIP * 3 - kButtonMarginDIP * 3,
+      -(kButtonHeightDIP + (kTitleBarHeightDIP - kButtonHeightDIP) / 2));
 }
 
 WindowDecorationsWayland::~WindowDecorationsWayland() {
@@ -86,16 +90,16 @@ void WindowDecorationsWayland::Draw() {
   }
 }
 
-void WindowDecorationsWayland::Resize(const int32_t width,
-                                      const int32_t height) {
-  titlebar_->SetPosition(0, -kTitleBarHeight);
-  titlebar_->Resize(width, kTitleBarHeight);
+void WindowDecorationsWayland::Resize(const int32_t width_dip,
+                                      const int32_t height_dip) {
+  titlebar_->SetPosition(0, -kTitleBarHeightDIP);
+  titlebar_->Resize(width_dip, kTitleBarHeightDIP);
 
   for (auto i = 0; i < buttons_.size(); i++) {
     buttons_[i]->SetPosition(
-        width - kButtonWidth * (i + 1) - kButtonMargin * (i + 1),
-        -(kButtonHeight + (kTitleBarHeight - kButtonHeight) / 2));
-    buttons_[i]->Resize(kButtonWidth, kButtonHeight);
+        width_dip - kButtonWidthDIP * (i + 1) - kButtonMarginDIP * (i + 1),
+        -(kButtonHeightDIP + (kTitleBarHeightDIP - kButtonHeightDIP) / 2));
+    buttons_[i]->Resize(kButtonWidthDIP, kButtonHeightDIP);
   }
 }
 
@@ -118,7 +122,7 @@ void WindowDecorationsWayland::DestroyContext() {
 }
 
 int32_t WindowDecorationsWayland::Height() const {
-  return kTitleBarHeight;
+  return kTitleBarHeightDIP;
 }
 
 }  // namespace flutter

--- a/src/flutter/shell/platform/linux_embedded/window/renderer/window_decorations_wayland.h
+++ b/src/flutter/shell/platform/linux_embedded/window/renderer/window_decorations_wayland.h
@@ -26,21 +26,26 @@ namespace flutter {
 
 class WindowDecorationsWayland {
  public:
+  // @param[in] width_dip   Logical width of the window (i.e. surface width).
+  // @param[in] height_dip  Logical height of the window (i.e. surface height).
   WindowDecorationsWayland(wl_display* display,
                            wl_compositor* compositor,
                            wl_subcompositor* subcompositor,
                            wl_surface* root_surface,
-                           int32_t width,
-                           int32_t height);
+                           int32_t width_dip,
+                           int32_t height_dip);
   ~WindowDecorationsWayland();
 
   void Draw();
 
-  void Resize(const int32_t width, const int32_t height);
+  // @param[in] width_dip   Logical width of the window (i.e. surface width).
+  // @param[in] height_dip  Logical height of the window (i.e. surface height).
+  void Resize(const int32_t width_dip, const int32_t height_dip);
 
   bool IsMatched(wl_surface* surface,
                  WindowDecoration::DecorationType decoration_type) const;
 
+  // Get height in logical pixels.
   int32_t Height() const;
 
  private:

--- a/src/flutter/shell/platform/linux_embedded/window_binding_handler.h
+++ b/src/flutter/shell/platform/linux_embedded/window_binding_handler.h
@@ -34,7 +34,9 @@ class WindowBindingHandler {
   virtual bool DispatchEvent() = 0;
 
   // Create a surface.
-  virtual bool CreateRenderSurface(int32_t width, int32_t height) = 0;
+  // @param[in] width_px       Physical width of the surface.
+  // @param[in] height_px      Physical height of the surface.
+  virtual bool CreateRenderSurface(int32_t width_px, int32_t height_px) = 0;
 
   // Destroy a surface which is currently used.
   virtual void DestroyRenderSurface() = 0;

--- a/src/flutter/shell/platform/linux_embedded/window_binding_handler_delegate.h
+++ b/src/flutter/shell/platform/linux_embedded/window_binding_handler_delegate.h
@@ -11,24 +11,32 @@ namespace flutter {
 
 class WindowBindingHandlerDelegate {
  public:
-  // Notifies delegate that backing window size has changed.
-  // Typically called by currently configured WindowBindingHandler
-  virtual void OnWindowSizeChanged(size_t width, size_t height) const = 0;
+  // Notifies delegate that backing window size has changed. Typically called by
+  // currently configured WindowBindingHandler
+  // @param[in] width_px       Physical width of the window.
+  // @param[in] height_px      Physical height of the window.
+  virtual void OnWindowSizeChanged(size_t width_px, size_t height_px) const = 0;
 
-  // Notifies delegate that backing window mouse has moved.
-  // Typically called by currently configured WindowBindingHandler
-  virtual void OnPointerMove(double x, double y) = 0;
+  // Notifies delegate that backing window mouse has moved. Typically called by
+  // currently configured WindowBindingHandler
+  // @param[in] x_px The x coordinate of the pointer event in physical pixels.
+  // @param[in] y_px The y coordinate of the pointer event in physical pixels.
+  virtual void OnPointerMove(double x_px, double y_px) = 0;
 
   // Notifies delegate that backing window mouse pointer button has been
   // pressed. Typically called by currently configured WindowBindingHandler
-  virtual void OnPointerDown(double x,
-                             double y,
+  // @param[in] x_px The x coordinate of the pointer event in physical pixels.
+  // @param[in] y_px The y coordinate of the pointer event in physical pixels.
+  virtual void OnPointerDown(double x_px,
+                             double y_px,
                              FlutterPointerMouseButtons button) = 0;
 
   // Notifies delegate that backing window mouse pointer button has been
   // released. Typically called by currently configured WindowBindingHandler
-  virtual void OnPointerUp(double x,
-                           double y,
+  // @param[in] x_px The x coordinate of the pointer event in physical pixels.
+  // @param[in] y_px The y coordinate of the pointer event in physical pixels.
+  virtual void OnPointerUp(double x_px,
+                           double y_px,
                            FlutterPointerMouseButtons button) = 0;
 
   // Notifies delegate that backing window mouse pointer has left the window.


### PR DESCRIPTION
> **Warning**
> 
> There are still parts of the code-base which are missing these annotations and would benefit from them. Therefore, this pull-request should be seen more like a starting point for this work.

This pull-request should contain **no functional changes**. It is only meant to annotate various methods and attributes with explicit information about whether logical or physical pixels are being used.

The current usage patterns have been used to determine whether to mark existing code as dealing with physical or logical coordinates.

This is part of a larger set of changes that are meant to add HighDPI support for Wayland.

### Naming conventions

The `_px` and `_dip` suffixes are sometimes used for variables depending on whether their data represents physical or logical pixels respectively. Obviously, this is not strictly necessary but it does make it easier to differentiate between the two when writing code that deals with both coordinate systems.

In Wayland terms, buffer coordinates correspond to physical pixels and surface coordinates correspond to logical pixels. Usually the relationship between the two is: `buffer_size = surface_size x output_scale`.

**Note**: I agree to delegate all rights related to this PR to Sony.
