### PR TITLE
Add initial support for HighDPI on Wayland

### DIFF
--- a/src/flutter/shell/platform/linux_embedded/public/flutter_elinux.h
+++ b/src/flutter/shell/platform/linux_embedded/public/flutter_elinux.h
@@ -76,10 +76,10 @@ enum FlutterDesktopViewRotation {
 
 // Properties for configuring a Flutter view instance.
 typedef struct {
-  // View width.
+  // View width in logical pixels.
   int width;
 
-  // View height.
+  // View height in logical pixels.
   int height;
 
   // View rotation setting.

--- a/src/flutter/shell/platform/linux_embedded/window/elinux_window.h
+++ b/src/flutter/shell/platform/linux_embedded/window/elinux_window.h
@@ -18,10 +18,14 @@ class ELinuxWindow {
   virtual bool IsValid() const = 0;
 
   // Get current window width in physical pixels.
-  uint32_t GetCurrentWidth() const { return view_properties_.width; }
+  uint32_t GetCurrentWidth() const {
+    return view_properties_.width * current_scale_;
+  }
 
   // Get current window height in physical pixels.
-  uint32_t GetCurrentHeight() const { return view_properties_.height; }
+  uint32_t GetCurrentHeight() const {
+    return view_properties_.height * current_scale_;
+  }
 
   void SetRotation(FlutterDesktopViewRotation rotation) {
     if (rotation == FlutterDesktopViewRotation::kRotation_90) {

--- a/src/flutter/shell/platform/linux_embedded/window/native_window_wayland_decoration.cc
+++ b/src/flutter/shell/platform/linux_embedded/window/native_window_wayland_decoration.cc
@@ -77,4 +77,13 @@ void NativeWindowWaylandDecoration::SetPosition(const int32_t x_dip,
   wl_subsurface_set_position(subsurface_, x_dip, y_dip);
 }
 
+void NativeWindowWaylandDecoration::SetScaleFactor(float scale_factor) {
+  if (!valid_) {
+    ELINUX_LOG(ERROR) << "Failed to set the scale factor of the window.";
+    return;
+  }
+
+  wl_surface_set_buffer_scale(surface_, scale_factor);
+}
+
 }  // namespace flutter

--- a/src/flutter/shell/platform/linux_embedded/window/native_window_wayland_decoration.h
+++ b/src/flutter/shell/platform/linux_embedded/window/native_window_wayland_decoration.h
@@ -29,6 +29,10 @@ class NativeWindowWaylandDecoration : public NativeWindow {
   // |NativeWindow|
   void SetPosition(const int32_t x_dip, const int32_t y_dip) override;
 
+  // Sets the scale factor for the next commit. Scale factor persists until a
+  // new one is set.
+  void SetScaleFactor(float scale_factor);
+
   wl_surface* Surface() const { return surface_; }
 
  private:

--- a/src/flutter/shell/platform/linux_embedded/window/renderer/window_decoration.h
+++ b/src/flutter/shell/platform/linux_embedded/window/renderer/window_decoration.h
@@ -36,6 +36,10 @@ class WindowDecoration {
   // @param[in] height_px  Physical height of the window.
   virtual void Resize(const size_t width_px, const size_t height_px) = 0;
 
+  // Sets the scale factor for the next commit. Scale factor persists until a
+  // new one is set.
+  virtual void SetScaleFactor(float scale_factor) = 0;
+
   void DestroyContext() const { render_surface_->DestroyContext(); };
 
   wl_surface* Surface() const { return native_window_->Surface(); };

--- a/src/flutter/shell/platform/linux_embedded/window/renderer/window_decoration_button.cc
+++ b/src/flutter/shell/platform/linux_embedded/window/renderer/window_decoration_button.cc
@@ -208,6 +208,10 @@ void WindowDecorationButton::Resize(const size_t width_px,
   render_surface_->Resize(width_px, height_px);
 }
 
+void WindowDecorationButton::SetScaleFactor(float scale_factor) {
+  native_window_->SetScaleFactor(scale_factor);
+}
+
 void WindowDecorationButton::LoadShader() {
   if (shader_) {
     return;

--- a/src/flutter/shell/platform/linux_embedded/window/renderer/window_decoration_button.h
+++ b/src/flutter/shell/platform/linux_embedded/window/renderer/window_decoration_button.h
@@ -26,6 +26,9 @@ class WindowDecorationButton : public WindowDecoration {
   // |WindowDecoration|
   void Resize(const size_t width_px, const size_t height_px) override;
 
+  // |WindowDecoration|
+  void SetScaleFactor(float scale_factor) override;
+
  private:
   void LoadShader();
 

--- a/src/flutter/shell/platform/linux_embedded/window/renderer/window_decoration_titlebar.cc
+++ b/src/flutter/shell/platform/linux_embedded/window/renderer/window_decoration_titlebar.cc
@@ -79,4 +79,8 @@ void WindowDecorationTitlebar::Resize(const size_t width_px,
   render_surface_->Resize(width_px, height_px);
 }
 
+void WindowDecorationTitlebar::SetScaleFactor(float scale_factor) {
+  native_window_->SetScaleFactor(scale_factor);
+}
+
 }  // namespace flutter

--- a/src/flutter/shell/platform/linux_embedded/window/renderer/window_decoration_titlebar.h
+++ b/src/flutter/shell/platform/linux_embedded/window/renderer/window_decoration_titlebar.h
@@ -23,6 +23,9 @@ class WindowDecorationTitlebar : public WindowDecoration {
 
   // |WindowDecoration|
   void Resize(const size_t width_px, const size_t height_px) override;
+
+  // |WindowDecoration|
+  void SetScaleFactor(float scale_factor) override;
 };
 
 }  // namespace flutter

--- a/src/flutter/shell/platform/linux_embedded/window/renderer/window_decorations_wayland.cc
+++ b/src/flutter/shell/platform/linux_embedded/window/renderer/window_decorations_wayland.cc
@@ -23,14 +23,15 @@ WindowDecorationsWayland::WindowDecorationsWayland(
     wl_subcompositor* subcompositor,
     wl_surface* root_surface,
     int32_t width_dip,
-    int32_t height_dip) {
+    int32_t height_dip,
+    double pixel_ratio) {
   constexpr bool sub_egl_display = true;
 
   // title-bar.
   titlebar_ = std::make_unique<WindowDecorationTitlebar>(
-      std::make_unique<NativeWindowWaylandDecoration>(compositor, subcompositor,
-                                                      root_surface, width_dip,
-                                                      kTitleBarHeightDIP),
+      std::make_unique<NativeWindowWaylandDecoration>(
+          compositor, subcompositor, root_surface, width_dip * pixel_ratio,
+          kTitleBarHeightDIP * pixel_ratio),
       std::make_unique<SurfaceDecoration>(std::make_unique<ContextEgl>(
           std::make_unique<EnvironmentEgl>(display, sub_egl_display))));
   titlebar_->SetPosition(0, -kTitleBarHeightDIP);
@@ -40,8 +41,8 @@ WindowDecorationsWayland::WindowDecorationsWayland(
   buttons_.push_back(std::make_unique<WindowDecorationButton>(
       type,
       std::make_unique<NativeWindowWaylandDecoration>(
-          compositor, subcompositor, root_surface, kButtonWidthDIP,
-          kButtonHeightDIP),
+          compositor, subcompositor, root_surface,
+          kButtonWidthDIP * pixel_ratio, kButtonHeightDIP * pixel_ratio),
       std::make_unique<SurfaceDecoration>(std::make_unique<ContextEgl>(
           std::make_unique<EnvironmentEgl>(display, sub_egl_display)))));
   buttons_[type]->SetPosition(
@@ -53,8 +54,8 @@ WindowDecorationsWayland::WindowDecorationsWayland(
   buttons_.push_back(std::make_unique<WindowDecorationButton>(
       type,
       std::make_unique<NativeWindowWaylandDecoration>(
-          compositor, subcompositor, root_surface, kButtonWidthDIP,
-          kButtonHeightDIP),
+          compositor, subcompositor, root_surface,
+          kButtonWidthDIP * pixel_ratio, kButtonHeightDIP * pixel_ratio),
       std::make_unique<SurfaceDecoration>(std::make_unique<ContextEgl>(
           std::make_unique<EnvironmentEgl>(display, sub_egl_display)))));
   buttons_[type]->SetPosition(
@@ -66,8 +67,8 @@ WindowDecorationsWayland::WindowDecorationsWayland(
   buttons_.push_back(std::make_unique<WindowDecorationButton>(
       type,
       std::make_unique<NativeWindowWaylandDecoration>(
-          compositor, subcompositor, root_surface, kButtonWidthDIP,
-          kButtonHeightDIP),
+          compositor, subcompositor, root_surface,
+          kButtonWidthDIP * pixel_ratio, kButtonHeightDIP * pixel_ratio),
       std::make_unique<SurfaceDecoration>(std::make_unique<ContextEgl>(
           std::make_unique<EnvironmentEgl>(display, sub_egl_display)))));
   buttons_[type]->SetPosition(
@@ -91,15 +92,19 @@ void WindowDecorationsWayland::Draw() {
 }
 
 void WindowDecorationsWayland::Resize(const int32_t width_dip,
-                                      const int32_t height_dip) {
+                                      const int32_t height_dip,
+                                      double pixel_ratio) {
+  titlebar_->SetScaleFactor(pixel_ratio);
   titlebar_->SetPosition(0, -kTitleBarHeightDIP);
-  titlebar_->Resize(width_dip, kTitleBarHeightDIP);
+  titlebar_->Resize(width_dip * pixel_ratio, kTitleBarHeightDIP * pixel_ratio);
 
   for (auto i = 0; i < buttons_.size(); i++) {
+    buttons_[i]->SetScaleFactor(pixel_ratio);
     buttons_[i]->SetPosition(
         width_dip - kButtonWidthDIP * (i + 1) - kButtonMarginDIP * (i + 1),
         -(kButtonHeightDIP + (kTitleBarHeightDIP - kButtonHeightDIP) / 2));
-    buttons_[i]->Resize(kButtonWidthDIP, kButtonHeightDIP);
+    buttons_[i]->Resize(kButtonWidthDIP * pixel_ratio,
+                        kButtonHeightDIP * pixel_ratio);
   }
 }
 

--- a/src/flutter/shell/platform/linux_embedded/window/renderer/window_decorations_wayland.h
+++ b/src/flutter/shell/platform/linux_embedded/window/renderer/window_decorations_wayland.h
@@ -28,19 +28,24 @@ class WindowDecorationsWayland {
  public:
   // @param[in] width_dip   Logical width of the window (i.e. surface width).
   // @param[in] height_dip  Logical height of the window (i.e. surface height).
+  // @param[in] pixel_ratio Physical / logical pixels ratio.
   WindowDecorationsWayland(wl_display* display,
                            wl_compositor* compositor,
                            wl_subcompositor* subcompositor,
                            wl_surface* root_surface,
                            int32_t width_dip,
-                           int32_t height_dip);
+                           int32_t height_dip,
+                           double pixel_ratio);
   ~WindowDecorationsWayland();
 
   void Draw();
 
   // @param[in] width_dip   Logical width of the window (i.e. surface width).
   // @param[in] height_dip  Logical height of the window (i.e. surface height).
-  void Resize(const int32_t width_dip, const int32_t height_dip);
+  // @param[in] pixel_ratio Physical / logical pixels ratio.
+  void Resize(const int32_t width_dip,
+              const int32_t height_dip,
+              double pixel_ratio);
 
   bool IsMatched(wl_surface* surface,
                  WindowDecoration::DecorationType decoration_type) const;


### PR DESCRIPTION
> **Warning**
>
> This pull-request is currently marked as a draft because it depends on a couple of pull-requests which haven't been merged yet: #311, #312, #313.

This pull-request contains various fixes related to HighDPI support on Wayland. Most of the fixes involve using the current window scale where needed and keeping the buffer scale in sync with the window scale.

The screen recordings below show a basic app before and after these fixes. The most notable difference is getting rid of the blurriness and the oversized widgets when running on a HighDPI screen on Wayland.

[before.webm](https://user-images.githubusercontent.com/433598/210018288-5a1d95ed-0727-42f8-b674-e361300f3d5f.webm)

[after.webm](https://user-images.githubusercontent.com/433598/210018287-464de543-6a89-460d-a385-790addbc6385.webm)



### TODO

- [x] rebase on `master` once the following pull-requests have been merged:
  - #311
  - #312
  - #313

**Note**: I agree to delegate all rights related to this PR to Sony.
