### PR TITLE
Refactor: convert view properties structs to classes

### DIFF
--- a/examples/flutter-drm-eglstream-backend/main.cc
+++ b/examples/flutter-drm-eglstream-backend/main.cc
@@ -25,7 +25,7 @@ int main(int argc, char** argv) {
   auto command_line_arguments = std::vector<std::string>();
   project.set_dart_entrypoint_arguments(std::move(command_line_arguments));
 
-  flutter::FlutterViewController::ViewProperties view_properties = {};
+  flutter::FlutterViewController::ViewProperties view_properties;
   view_properties.width = options.WindowWidth();
   view_properties.height = options.WindowHeight();
   view_properties.view_mode = options.WindowViewMode();

--- a/examples/flutter-drm-gbm-backend/main.cc
+++ b/examples/flutter-drm-gbm-backend/main.cc
@@ -25,7 +25,7 @@ int main(int argc, char** argv) {
   auto command_line_arguments = std::vector<std::string>();
   project.set_dart_entrypoint_arguments(std::move(command_line_arguments));
 
-  flutter::FlutterViewController::ViewProperties view_properties = {};
+  flutter::FlutterViewController::ViewProperties view_properties;
   view_properties.width = options.WindowWidth();
   view_properties.height = options.WindowHeight();
   view_properties.view_mode = options.WindowViewMode();

--- a/examples/flutter-external-texture-plugin/main.cc
+++ b/examples/flutter-external-texture-plugin/main.cc
@@ -25,7 +25,7 @@ int main(int argc, char** argv) {
   auto command_line_arguments = std::vector<std::string>();
   project.set_dart_entrypoint_arguments(std::move(command_line_arguments));
 
-  flutter::FlutterViewController::ViewProperties view_properties = {};
+  flutter::FlutterViewController::ViewProperties view_properties;
   view_properties.width = options.WindowWidth();
   view_properties.height = options.WindowHeight();
   view_properties.view_mode = options.WindowViewMode();

--- a/examples/flutter-video-player-plugin/main.cc
+++ b/examples/flutter-video-player-plugin/main.cc
@@ -25,7 +25,7 @@ int main(int argc, char** argv) {
   auto command_line_arguments = std::vector<std::string>();
   project.set_dart_entrypoint_arguments(std::move(command_line_arguments));
 
-  flutter::FlutterViewController::ViewProperties view_properties = {};
+  flutter::FlutterViewController::ViewProperties view_properties;
   view_properties.width = options.WindowWidth();
   view_properties.height = options.WindowHeight();
   view_properties.view_mode = options.WindowViewMode();

--- a/examples/flutter-wayland-client/main.cc
+++ b/examples/flutter-wayland-client/main.cc
@@ -25,7 +25,7 @@ int main(int argc, char** argv) {
   auto command_line_arguments = std::vector<std::string>();
   project.set_dart_entrypoint_arguments(std::move(command_line_arguments));
 
-  flutter::FlutterViewController::ViewProperties view_properties = {};
+  flutter::FlutterViewController::ViewProperties view_properties;
   view_properties.width = options.WindowWidth();
   view_properties.height = options.WindowHeight();
   view_properties.view_mode = options.WindowViewMode();

--- a/examples/flutter-x11-client/main.cc
+++ b/examples/flutter-x11-client/main.cc
@@ -25,7 +25,7 @@ int main(int argc, char** argv) {
   auto command_line_arguments = std::vector<std::string>();
   project.set_dart_entrypoint_arguments(std::move(command_line_arguments));
 
-  flutter::FlutterViewController::ViewProperties view_properties = {};
+  flutter::FlutterViewController::ViewProperties view_properties;
   view_properties.width = options.WindowWidth();
   view_properties.height = options.WindowHeight();
   view_properties.view_mode = options.WindowViewMode();

--- a/src/client_wrapper/flutter_view_controller.cc
+++ b/src/client_wrapper/flutter_view_controller.cc
@@ -14,7 +14,7 @@ FlutterViewController::FlutterViewController(
     const DartProject& project) {
   engine_ = std::make_unique<FlutterEngine>(project);
 
-  FlutterDesktopViewProperties c_view_properties = {};
+  FlutterDesktopViewProperties c_view_properties;
   c_view_properties.width = view_properties.width;
   c_view_properties.height = view_properties.height;
   c_view_properties.view_rotation =

--- a/src/client_wrapper/include/flutter/flutter_view_controller.h
+++ b/src/client_wrapper/include/flutter/flutter_view_controller.h
@@ -44,7 +44,8 @@ class FlutterViewController {
   };
 
   // Properties for configuring a Flutter view instance.
-  typedef struct {
+  class ViewProperties {
+   public:
     // View width.
     int width;
 
@@ -71,7 +72,7 @@ class FlutterViewController {
     // Force scale factor specified by command line argument
     bool force_scale_factor;
     double scale_factor;
-  } ViewProperties;
+  };
 
   // Creates a FlutterView that can be parented into a Windows View hierarchy
   // either using HWNDs or in the future into a CoreWindow, or using compositor.

--- a/src/flutter/shell/platform/linux_embedded/public/flutter_elinux.h
+++ b/src/flutter/shell/platform/linux_embedded/public/flutter_elinux.h
@@ -75,7 +75,8 @@ enum FlutterDesktopViewRotation {
 };
 
 // Properties for configuring a Flutter view instance.
-typedef struct {
+class FlutterDesktopViewProperties {
+ public:
   // View width in logical pixels.
   int width;
 
@@ -102,7 +103,7 @@ typedef struct {
   // Force scale factor specified by command line argument
   bool force_scale_factor;
   double scale_factor;
-} FlutterDesktopViewProperties;
+};
 
 // ========== View Controller ==========
 


### PR DESCRIPTION
Convert `FlutterDesktopViewProperties` and `ViewProperties` from structs to classes. The main motivation for this change is to be able to use `std::string` member variables as view properties.

This is necessary for an upcoming pull-request (#316) that allows configuring the window title and app-id using these view properties.

### Warning

:warning: Please review this very carefully. I'm not familiar enough with C++ and the code-base to understand if this might have unintended side-effects. Also, feel free to suggest alternative solutions it these changes are not deemed acceptable.

**Note**: I agree to delegate all rights related to this PR to Sony.