### PR TITLE
Make window title and app ID configurable

### DIFF
--- a/examples/flutter-drm-eglstream-backend/flutter_embedder_options.h
+++ b/examples/flutter-drm-eglstream-backend/flutter_embedder_options.h
@@ -22,8 +22,8 @@ class FlutterEmbedderOptions {
                     "Window rotation(degree) [0(default)|90|180|270]", 0,
                     false);
     options_.AddDouble("force-scale-factor", "s",
-                    "Force a scale factor instead using default value", 1.0,
-                    false);
+                       "Force a scale factor instead using default value", 1.0,
+                       false);
 #if defined(FLUTTER_TARGET_BACKEND_GBM) || \
     defined(FLUTTER_TARGET_BACKEND_EGLSTREAM)
     // no more options.
@@ -33,6 +33,9 @@ class FlutterEmbedderOptions {
     options_.AddInt("width", "w", "Window width", 1280, false);
     options_.AddInt("height", "h", "Window height", 720, false);
 #else  // FLUTTER_TARGET_BACKEND_WAYLAND
+    options_.AddString("title", "t", "Window title", "Flutter", false);
+    options_.AddString("app-id", "a", "XDG App ID", "dev.flutter.elinux",
+                       false);
     options_.AddWithoutValue("onscreen-keyboard", "k",
                              "Enable on-screen keyboard", false);
     options_.AddWithoutValue("window-decoration", "d",
@@ -53,6 +56,8 @@ class FlutterEmbedderOptions {
     }
 
     bundle_path_ = options_.GetValue<std::string>("bundle");
+    window_title_ = options_.GetValue<std::string>("title");
+    window_app_id_ = options_.GetValue<std::string>("app-id");
     use_mouse_cursor_ = !options_.Exist("no-cursor");
     if (options_.Exist("rotation")) {
       switch (options_.GetValue<int>("rotation")) {
@@ -112,6 +117,8 @@ class FlutterEmbedderOptions {
   }
 
   std::string BundlePath() const { return bundle_path_; }
+  std::string WindowTitle() const { return window_title_; }
+  std::string WindowAppID() const { return window_app_id_; }
   bool IsUseMouseCursor() const { return use_mouse_cursor_; }
   bool IsUseOnscreenKeyboard() const { return use_onscreen_keyboard_; }
   bool IsUseWindowDecoraation() const { return use_window_decoration_; }
@@ -130,6 +137,8 @@ class FlutterEmbedderOptions {
   commandline::CommandOptions options_;
 
   std::string bundle_path_;
+  std::string window_title_;
+  std::string window_app_id_;
   bool use_mouse_cursor_ = true;
   bool use_onscreen_keyboard_ = false;
   bool use_window_decoration_ = false;

--- a/examples/flutter-drm-eglstream-backend/main.cc
+++ b/examples/flutter-drm-eglstream-backend/main.cc
@@ -30,6 +30,8 @@ int main(int argc, char** argv) {
   view_properties.height = options.WindowHeight();
   view_properties.view_mode = options.WindowViewMode();
   view_properties.view_rotation = options.WindowRotation();
+  view_properties.title = options.WindowTitle();
+  view_properties.app_id = options.WindowAppID();
   view_properties.use_mouse_cursor = options.IsUseMouseCursor();
   view_properties.use_onscreen_keyboard = options.IsUseOnscreenKeyboard();
   view_properties.use_window_decoration = options.IsUseWindowDecoraation();

--- a/examples/flutter-drm-gbm-backend/flutter_embedder_options.h
+++ b/examples/flutter-drm-gbm-backend/flutter_embedder_options.h
@@ -22,8 +22,8 @@ class FlutterEmbedderOptions {
                     "Window rotation(degree) [0(default)|90|180|270]", 0,
                     false);
     options_.AddDouble("force-scale-factor", "s",
-                    "Force a scale factor instead using default value", 1.0,
-                    false);
+                       "Force a scale factor instead using default value", 1.0,
+                       false);
 #if defined(FLUTTER_TARGET_BACKEND_GBM) || \
     defined(FLUTTER_TARGET_BACKEND_EGLSTREAM)
     // no more options.
@@ -33,6 +33,9 @@ class FlutterEmbedderOptions {
     options_.AddInt("width", "w", "Window width", 1280, false);
     options_.AddInt("height", "h", "Window height", 720, false);
 #else  // FLUTTER_TARGET_BACKEND_WAYLAND
+    options_.AddString("title", "t", "Window title", "Flutter", false);
+    options_.AddString("app-id", "a", "XDG App ID", "dev.flutter.elinux",
+                       false);
     options_.AddWithoutValue("onscreen-keyboard", "k",
                              "Enable on-screen keyboard", false);
     options_.AddWithoutValue("window-decoration", "d",
@@ -53,6 +56,8 @@ class FlutterEmbedderOptions {
     }
 
     bundle_path_ = options_.GetValue<std::string>("bundle");
+    window_title_ = options_.GetValue<std::string>("title");
+    window_app_id_ = options_.GetValue<std::string>("app-id");
     use_mouse_cursor_ = !options_.Exist("no-cursor");
     if (options_.Exist("rotation")) {
       switch (options_.GetValue<int>("rotation")) {
@@ -112,6 +117,8 @@ class FlutterEmbedderOptions {
   }
 
   std::string BundlePath() const { return bundle_path_; }
+  std::string WindowTitle() const { return window_title_; }
+  std::string WindowAppID() const { return window_app_id_; }
   bool IsUseMouseCursor() const { return use_mouse_cursor_; }
   bool IsUseOnscreenKeyboard() const { return use_onscreen_keyboard_; }
   bool IsUseWindowDecoraation() const { return use_window_decoration_; }
@@ -130,6 +137,8 @@ class FlutterEmbedderOptions {
   commandline::CommandOptions options_;
 
   std::string bundle_path_;
+  std::string window_title_;
+  std::string window_app_id_;
   bool use_mouse_cursor_ = true;
   bool use_onscreen_keyboard_ = false;
   bool use_window_decoration_ = false;

--- a/examples/flutter-drm-gbm-backend/main.cc
+++ b/examples/flutter-drm-gbm-backend/main.cc
@@ -30,6 +30,8 @@ int main(int argc, char** argv) {
   view_properties.height = options.WindowHeight();
   view_properties.view_mode = options.WindowViewMode();
   view_properties.view_rotation = options.WindowRotation();
+  view_properties.title = options.WindowTitle();
+  view_properties.app_id = options.WindowAppID();
   view_properties.use_mouse_cursor = options.IsUseMouseCursor();
   view_properties.use_onscreen_keyboard = options.IsUseOnscreenKeyboard();
   view_properties.use_window_decoration = options.IsUseWindowDecoraation();

--- a/examples/flutter-external-texture-plugin/flutter_embedder_options.h
+++ b/examples/flutter-external-texture-plugin/flutter_embedder_options.h
@@ -22,8 +22,8 @@ class FlutterEmbedderOptions {
                     "Window rotation(degree) [0(default)|90|180|270]", 0,
                     false);
     options_.AddDouble("force-scale-factor", "s",
-                    "Force a scale factor instead using default value", 1.0,
-                    false);
+                       "Force a scale factor instead using default value", 1.0,
+                       false);
 #if defined(FLUTTER_TARGET_BACKEND_GBM) || \
     defined(FLUTTER_TARGET_BACKEND_EGLSTREAM)
     // no more options.
@@ -33,6 +33,9 @@ class FlutterEmbedderOptions {
     options_.AddInt("width", "w", "Window width", 1280, false);
     options_.AddInt("height", "h", "Window height", 720, false);
 #else  // FLUTTER_TARGET_BACKEND_WAYLAND
+    options_.AddString("title", "t", "Window title", "Flutter", false);
+    options_.AddString("app-id", "a", "XDG App ID", "dev.flutter.elinux",
+                       false);
     options_.AddWithoutValue("onscreen-keyboard", "k",
                              "Enable on-screen keyboard", false);
     options_.AddWithoutValue("window-decoration", "d",
@@ -53,6 +56,8 @@ class FlutterEmbedderOptions {
     }
 
     bundle_path_ = options_.GetValue<std::string>("bundle");
+    window_title_ = options_.GetValue<std::string>("title");
+    window_app_id_ = options_.GetValue<std::string>("app-id");
     use_mouse_cursor_ = !options_.Exist("no-cursor");
     if (options_.Exist("rotation")) {
       switch (options_.GetValue<int>("rotation")) {
@@ -112,6 +117,8 @@ class FlutterEmbedderOptions {
   }
 
   std::string BundlePath() const { return bundle_path_; }
+  std::string WindowTitle() const { return window_title_; }
+  std::string WindowAppID() const { return window_app_id_; }
   bool IsUseMouseCursor() const { return use_mouse_cursor_; }
   bool IsUseOnscreenKeyboard() const { return use_onscreen_keyboard_; }
   bool IsUseWindowDecoraation() const { return use_window_decoration_; }
@@ -130,6 +137,8 @@ class FlutterEmbedderOptions {
   commandline::CommandOptions options_;
 
   std::string bundle_path_;
+  std::string window_title_;
+  std::string window_app_id_;
   bool use_mouse_cursor_ = true;
   bool use_onscreen_keyboard_ = false;
   bool use_window_decoration_ = false;

--- a/examples/flutter-external-texture-plugin/main.cc
+++ b/examples/flutter-external-texture-plugin/main.cc
@@ -30,6 +30,8 @@ int main(int argc, char** argv) {
   view_properties.height = options.WindowHeight();
   view_properties.view_mode = options.WindowViewMode();
   view_properties.view_rotation = options.WindowRotation();
+  view_properties.title = options.WindowTitle();
+  view_properties.app_id = options.WindowAppID();
   view_properties.use_mouse_cursor = options.IsUseMouseCursor();
   view_properties.use_onscreen_keyboard = options.IsUseOnscreenKeyboard();
   view_properties.use_window_decoration = options.IsUseWindowDecoraation();

--- a/examples/flutter-video-player-plugin/flutter_embedder_options.h
+++ b/examples/flutter-video-player-plugin/flutter_embedder_options.h
@@ -22,8 +22,8 @@ class FlutterEmbedderOptions {
                     "Window rotation(degree) [0(default)|90|180|270]", 0,
                     false);
     options_.AddDouble("force-scale-factor", "s",
-                    "Force a scale factor instead using default value", 1.0,
-                    false);
+                       "Force a scale factor instead using default value", 1.0,
+                       false);
 #if defined(FLUTTER_TARGET_BACKEND_GBM) || \
     defined(FLUTTER_TARGET_BACKEND_EGLSTREAM)
     // no more options.
@@ -33,6 +33,9 @@ class FlutterEmbedderOptions {
     options_.AddInt("width", "w", "Window width", 1280, false);
     options_.AddInt("height", "h", "Window height", 720, false);
 #else  // FLUTTER_TARGET_BACKEND_WAYLAND
+    options_.AddString("title", "t", "Window title", "Flutter", false);
+    options_.AddString("app-id", "a", "XDG App ID", "dev.flutter.elinux",
+                       false);
     options_.AddWithoutValue("onscreen-keyboard", "k",
                              "Enable on-screen keyboard", false);
     options_.AddWithoutValue("window-decoration", "d",
@@ -53,6 +56,8 @@ class FlutterEmbedderOptions {
     }
 
     bundle_path_ = options_.GetValue<std::string>("bundle");
+    window_title_ = options_.GetValue<std::string>("title");
+    window_app_id_ = options_.GetValue<std::string>("app-id");
     use_mouse_cursor_ = !options_.Exist("no-cursor");
     if (options_.Exist("rotation")) {
       switch (options_.GetValue<int>("rotation")) {
@@ -112,6 +117,8 @@ class FlutterEmbedderOptions {
   }
 
   std::string BundlePath() const { return bundle_path_; }
+  std::string WindowTitle() const { return window_title_; }
+  std::string WindowAppID() const { return window_app_id_; }
   bool IsUseMouseCursor() const { return use_mouse_cursor_; }
   bool IsUseOnscreenKeyboard() const { return use_onscreen_keyboard_; }
   bool IsUseWindowDecoraation() const { return use_window_decoration_; }
@@ -130,6 +137,8 @@ class FlutterEmbedderOptions {
   commandline::CommandOptions options_;
 
   std::string bundle_path_;
+  std::string window_title_;
+  std::string window_app_id_;
   bool use_mouse_cursor_ = true;
   bool use_onscreen_keyboard_ = false;
   bool use_window_decoration_ = false;

--- a/examples/flutter-video-player-plugin/main.cc
+++ b/examples/flutter-video-player-plugin/main.cc
@@ -30,6 +30,8 @@ int main(int argc, char** argv) {
   view_properties.height = options.WindowHeight();
   view_properties.view_mode = options.WindowViewMode();
   view_properties.view_rotation = options.WindowRotation();
+  view_properties.title = options.WindowTitle();
+  view_properties.app_id = options.WindowAppID();
   view_properties.use_mouse_cursor = options.IsUseMouseCursor();
   view_properties.use_onscreen_keyboard = options.IsUseOnscreenKeyboard();
   view_properties.use_window_decoration = options.IsUseWindowDecoraation();

--- a/examples/flutter-wayland-client/flutter_embedder_options.h
+++ b/examples/flutter-wayland-client/flutter_embedder_options.h
@@ -22,8 +22,8 @@ class FlutterEmbedderOptions {
                     "Window rotation(degree) [0(default)|90|180|270]", 0,
                     false);
     options_.AddDouble("force-scale-factor", "s",
-                    "Force a scale factor instead using default value", 1.0,
-                    false);
+                       "Force a scale factor instead using default value", 1.0,
+                       false);
 #if defined(FLUTTER_TARGET_BACKEND_GBM) || \
     defined(FLUTTER_TARGET_BACKEND_EGLSTREAM)
     // no more options.
@@ -33,6 +33,9 @@ class FlutterEmbedderOptions {
     options_.AddInt("width", "w", "Window width", 1280, false);
     options_.AddInt("height", "h", "Window height", 720, false);
 #else  // FLUTTER_TARGET_BACKEND_WAYLAND
+    options_.AddString("title", "t", "Window title", "Flutter", false);
+    options_.AddString("app-id", "a", "XDG App ID", "dev.flutter.elinux",
+                       false);
     options_.AddWithoutValue("onscreen-keyboard", "k",
                              "Enable on-screen keyboard", false);
     options_.AddWithoutValue("window-decoration", "d",
@@ -53,6 +56,8 @@ class FlutterEmbedderOptions {
     }
 
     bundle_path_ = options_.GetValue<std::string>("bundle");
+    window_title_ = options_.GetValue<std::string>("title");
+    window_app_id_ = options_.GetValue<std::string>("app-id");
     use_mouse_cursor_ = !options_.Exist("no-cursor");
     if (options_.Exist("rotation")) {
       switch (options_.GetValue<int>("rotation")) {
@@ -112,6 +117,8 @@ class FlutterEmbedderOptions {
   }
 
   std::string BundlePath() const { return bundle_path_; }
+  std::string WindowTitle() const { return window_title_; }
+  std::string WindowAppID() const { return window_app_id_; }
   bool IsUseMouseCursor() const { return use_mouse_cursor_; }
   bool IsUseOnscreenKeyboard() const { return use_onscreen_keyboard_; }
   bool IsUseWindowDecoraation() const { return use_window_decoration_; }
@@ -130,6 +137,8 @@ class FlutterEmbedderOptions {
   commandline::CommandOptions options_;
 
   std::string bundle_path_;
+  std::string window_title_;
+  std::string window_app_id_;
   bool use_mouse_cursor_ = true;
   bool use_onscreen_keyboard_ = false;
   bool use_window_decoration_ = false;

--- a/examples/flutter-wayland-client/main.cc
+++ b/examples/flutter-wayland-client/main.cc
@@ -30,6 +30,8 @@ int main(int argc, char** argv) {
   view_properties.height = options.WindowHeight();
   view_properties.view_mode = options.WindowViewMode();
   view_properties.view_rotation = options.WindowRotation();
+  view_properties.title = options.WindowTitle();
+  view_properties.app_id = options.WindowAppID();
   view_properties.use_mouse_cursor = options.IsUseMouseCursor();
   view_properties.use_onscreen_keyboard = options.IsUseOnscreenKeyboard();
   view_properties.use_window_decoration = options.IsUseWindowDecoraation();

--- a/examples/flutter-x11-client/flutter_embedder_options.h
+++ b/examples/flutter-x11-client/flutter_embedder_options.h
@@ -22,8 +22,8 @@ class FlutterEmbedderOptions {
                     "Window rotation(degree) [0(default)|90|180|270]", 0,
                     false);
     options_.AddDouble("force-scale-factor", "s",
-                    "Force a scale factor instead using default value", 1.0,
-                    false);
+                       "Force a scale factor instead using default value", 1.0,
+                       false);
 #if defined(FLUTTER_TARGET_BACKEND_GBM) || \
     defined(FLUTTER_TARGET_BACKEND_EGLSTREAM)
     // no more options.
@@ -33,6 +33,9 @@ class FlutterEmbedderOptions {
     options_.AddInt("width", "w", "Window width", 1280, false);
     options_.AddInt("height", "h", "Window height", 720, false);
 #else  // FLUTTER_TARGET_BACKEND_WAYLAND
+    options_.AddString("title", "t", "Window title", "Flutter", false);
+    options_.AddString("app-id", "a", "XDG App ID", "dev.flutter.elinux",
+                       false);
     options_.AddWithoutValue("onscreen-keyboard", "k",
                              "Enable on-screen keyboard", false);
     options_.AddWithoutValue("window-decoration", "d",
@@ -53,6 +56,8 @@ class FlutterEmbedderOptions {
     }
 
     bundle_path_ = options_.GetValue<std::string>("bundle");
+    window_title_ = options_.GetValue<std::string>("title");
+    window_app_id_ = options_.GetValue<std::string>("app-id");
     use_mouse_cursor_ = !options_.Exist("no-cursor");
     if (options_.Exist("rotation")) {
       switch (options_.GetValue<int>("rotation")) {
@@ -112,6 +117,8 @@ class FlutterEmbedderOptions {
   }
 
   std::string BundlePath() const { return bundle_path_; }
+  std::string WindowTitle() const { return window_title_; }
+  std::string WindowAppID() const { return window_app_id_; }
   bool IsUseMouseCursor() const { return use_mouse_cursor_; }
   bool IsUseOnscreenKeyboard() const { return use_onscreen_keyboard_; }
   bool IsUseWindowDecoraation() const { return use_window_decoration_; }
@@ -130,6 +137,8 @@ class FlutterEmbedderOptions {
   commandline::CommandOptions options_;
 
   std::string bundle_path_;
+  std::string window_title_;
+  std::string window_app_id_;
   bool use_mouse_cursor_ = true;
   bool use_onscreen_keyboard_ = false;
   bool use_window_decoration_ = false;

--- a/examples/flutter-x11-client/main.cc
+++ b/examples/flutter-x11-client/main.cc
@@ -30,6 +30,8 @@ int main(int argc, char** argv) {
   view_properties.height = options.WindowHeight();
   view_properties.view_mode = options.WindowViewMode();
   view_properties.view_rotation = options.WindowRotation();
+  view_properties.title = options.WindowTitle();
+  view_properties.app_id = options.WindowAppID();
   view_properties.use_mouse_cursor = options.IsUseMouseCursor();
   view_properties.use_onscreen_keyboard = options.IsUseOnscreenKeyboard();
   view_properties.use_window_decoration = options.IsUseWindowDecoraation();

--- a/src/client_wrapper/flutter_view_controller.cc
+++ b/src/client_wrapper/flutter_view_controller.cc
@@ -29,6 +29,12 @@ FlutterViewController::FlutterViewController(
       (view_properties.view_mode == ViewMode::kFullscreen)
           ? FlutterDesktopViewMode::kFullscreen
           : FlutterDesktopViewMode::kNormalscreen;
+  c_view_properties.title = view_properties.title.has_value()
+                                ? (*view_properties.title).c_str()
+                                : nullptr;
+  c_view_properties.app_id = view_properties.app_id.has_value()
+                                 ? (*view_properties.app_id).c_str()
+                                 : nullptr;
   c_view_properties.use_mouse_cursor = view_properties.use_mouse_cursor;
   c_view_properties.use_onscreen_keyboard =
       view_properties.use_onscreen_keyboard;

--- a/src/client_wrapper/include/flutter/flutter_view_controller.h
+++ b/src/client_wrapper/include/flutter/flutter_view_controller.h
@@ -9,6 +9,7 @@
 
 #include <memory>
 #include <optional>
+#include <string>
 
 #include "dart_project.h"
 #include "flutter_engine.h"
@@ -57,6 +58,13 @@ class FlutterViewController {
     // View display mode. If you set kFullscreen, the parameters of both `width`
     // and `height` will be ignored.
     ViewMode view_mode;
+
+    // View title.
+    std::optional<std::string> title;
+
+    // View XDG application ID. As a best practice, it is suggested to select an
+    // app ID that matches the basename of the application's .desktop file.
+    std::optional<std::string> app_id;
 
     // Uses mouse cursor.
     bool use_mouse_cursor;

--- a/src/flutter/shell/platform/linux_embedded/public/flutter_elinux.h
+++ b/src/flutter/shell/platform/linux_embedded/public/flutter_elinux.h
@@ -89,6 +89,13 @@ typedef struct {
   // and `height` will be ignored.
   FlutterDesktopViewMode view_mode;
 
+  // View title.
+  const char* title;
+
+  // View XDG application ID. As a best practice, it is suggested to select an
+  // app ID that matches the basename of the application's .desktop file.
+  const char* app_id;
+
   // Uses mouse cursor.
   bool use_mouse_cursor;
 

--- a/src/flutter/shell/platform/linux_embedded/window/elinux_window_wayland.cc
+++ b/src/flutter/shell/platform/linux_embedded/window/elinux_window_wayland.cc
@@ -1195,7 +1195,12 @@ bool ELinuxWindowWayland::CreateRenderSurface(int32_t width_px,
   xdg_surface_add_listener(xdg_surface_, &kXdgSurfaceListener, this);
 
   xdg_toplevel_ = xdg_surface_get_toplevel(xdg_surface_);
-  xdg_toplevel_set_title(xdg_toplevel_, "Flutter");
+  if (view_properties_.title != nullptr) {
+    xdg_toplevel_set_title(xdg_toplevel_, view_properties_.title);
+  }
+  if (view_properties_.app_id != nullptr) {
+    xdg_toplevel_set_app_id(xdg_toplevel_, view_properties_.app_id);
+  }
   xdg_toplevel_add_listener(xdg_toplevel_, &kXdgToplevelListener, this);
   wl_surface_set_buffer_scale(native_window_->Surface(), current_scale_);
   wl_surface_commit(native_window_->Surface());


### PR DESCRIPTION
Remove the [hard-coded "Flutter" window title](https://github.com/sony/flutter-embedded-linux/blob/d88c3c55d9bce06a864f5b51a6d5a9a71293a336/src/flutter/shell/platform/linux_embedded/window/elinux_window_wayland.cc#L1198) on Wayland and make it configurable as part of the `ViewProperties`. Also, add support for configuring the [window's app ID](https://wayland.app/protocols/xdg-shell#xdg_toplevel:request:set_app_id) too.

Currently these properties are only used on Wayland but it may make sense to use them for X11 too (but that's not part of this pull-request).

**Note**: I agree to delegate all rights related to this PR to Sony.