### PR TITLE
Set decoration button GL viewport to fix resize issues

### DIFF
--- a/src/flutter/shell/platform/linux_embedded/window/renderer/window_decoration_button.cc
+++ b/src/flutter/shell/platform/linux_embedded/window/renderer/window_decoration_button.cc
@@ -21,6 +21,7 @@ struct GlProcs {
   PFNGLENABLEPROC glEnable;
   PFNGLCLEARCOLORPROC glClearColor;
   PFNGLCLEARPROC glClear;
+  PFNGLVIEWPORTPROC glViewport;
   PFNGLENABLEVERTEXATTRIBARRAYPROC glEnableVertexAttribArray;
   PFNGLVERTEXATTRIBPOINTERPROC glVertexAttribPointer;
   PFNGLDRAWARRAYSPROC glDrawArrays;
@@ -41,6 +42,8 @@ static const GlProcs& GlProcs() {
         eglGetProcAddress("glClearColor"));
     procs.glClear =
         reinterpret_cast<PFNGLCLEARPROC>(eglGetProcAddress("glClear"));
+    procs.glViewport =
+        reinterpret_cast<PFNGLVIEWPORTPROC>(eglGetProcAddress("glViewport"));
     procs.glEnableVertexAttribArray =
         reinterpret_cast<PFNGLENABLEVERTEXATTRIBARRAYPROC>(
             eglGetProcAddress("glEnableVertexAttribArray"));
@@ -61,7 +64,7 @@ static const GlProcs& GlProcs() {
     procs.valid = procs.glEnable && procs.glClearColor && procs.glClear &&
                   procs.glEnableVertexAttribArray && procs.glLineWidth &&
                   procs.glVertexAttribPointer && procs.glDrawArrays &&
-                  procs.glDisableVertexAttribArray &&
+                  procs.glDisableVertexAttribArray && procs.glViewport &&
                   procs.glBindAttribLocation && procs.glUseProgram;
     if (!procs.valid) {
       ELINUX_LOG(ERROR) << "Failed to load GlProcs";
@@ -116,6 +119,7 @@ void WindowDecorationButton::Draw() {
   {
     gl.glClearColor(100 / 255.0f, 100 / 255.0f, 100 / 255.0f, 1.0f);
     gl.glClear(GL_COLOR_BUFFER_BIT);
+    gl.glViewport(0, 0, native_window_->Width(), native_window_->Height());
     {
       if (!shader_) {
         LoadShader();


### PR DESCRIPTION
This pull-request sets the GL viewport for the window decoration buttons. This is necessary because otherwise the buttons are not drawn correctly when moving the window between outputs with different scale factors.

As an example of this issue see the screen recordings below where the output on the right (visible in the recording) has a scale factor of 1 and the output on the left (**not** visible in the recording) has a scale factor of 2.

[before.webm](https://user-images.githubusercontent.com/433598/210281792-5396db7d-5a41-4e3c-bfba-52730c51e62f.webm)

[after.webm](https://user-images.githubusercontent.com/433598/210281430-2941a453-e62b-433d-8cc0-1077048514cf.webm)


**Note**: I agree to delegate all rights related to this PR to Sony.
