### PR TITLE
Wayland: Always respect XDG configure size regardless of state

### DIFF
--- a/src/flutter/shell/platform/linux_embedded/window/elinux_window_wayland.cc
+++ b/src/flutter/shell/platform/linux_embedded/window/elinux_window_wayland.cc
@@ -91,36 +91,14 @@ const xdg_toplevel_listener ELinuxWindowWayland::kXdgToplevelListener = {
            int32_t width,
            int32_t height,
            wl_array* states) {
-          auto is_maximized = false;
-          auto is_resizing = false;
-          uint32_t* state = static_cast<uint32_t*>(states->data);
-          for (auto i = 0; i < states->size; i++) {
-            switch (*state) {
-              case XDG_TOPLEVEL_STATE_MAXIMIZED:
-                is_maximized = true;
-                break;
-              case XDG_TOPLEVEL_STATE_RESIZING:
-                is_resizing = true;
-                break;
-              case XDG_TOPLEVEL_STATE_ACTIVATED:
-              case XDG_TOPLEVEL_STATE_FULLSCREEN:
-              default:
-                break;
-            }
-            state++;
-          }
-
           auto self = reinterpret_cast<ELinuxWindowWayland*>(data);
           if (self->current_rotation_ == 90 || self->current_rotation_ == 270) {
             std::swap(width, height);
           }
 
-          int32_t next_width = 0;
-          int32_t next_height = 0;
-          if (is_maximized || is_resizing) {
-            next_width = width;
-            next_height = height;
-          } else if (self->restore_window_required_) {
+          int32_t next_width = width;
+          int32_t next_height = height;
+          if (self->restore_window_required_) {
             self->restore_window_required_ = false;
             next_width = self->restore_window_width_;
             next_height = self->restore_window_height_;


### PR DESCRIPTION
The previous logic was ignoring most of the toplevel `configure` events *unless* the window was maximized or was being resized. This pull-request removes that check in order to always respect the size suggested by the compositor.

This is particularly important for tiling compositors (e.g.: sway) where the window can be arbitrarily resized by the compositor even when it's not maximized (e.g.: when it's part of a tiled layout). The screen recordings below show some comparison videos of the old and new behavior.

#### Warning

Please review this carefully because it's not very clear what was the *original* purpose of the checks that are being removed in this pull-request. That being said, I have tested the new code in Sway, Weston, GNOME and Hyprland and it does seem to work as expected (as far as I can tell).

[before.webm](https://user-images.githubusercontent.com/433598/210647105-0b2124fe-da33-4ff3-b712-3688d2768c72.webm)

[after.webm](https://user-images.githubusercontent.com/433598/210647096-b1990bf7-3f0f-40c0-a6c5-be611b791cb3.webm)

**Note**: I agree to delegate all rights related to this PR to Sony.