### PR TITLE
Implement support for xdg-decoration

### DIFF
--- a/cmake/build.cmake
+++ b/cmake/build.cmake
@@ -63,6 +63,11 @@ else()
     CODE_FILE "${_wayland_protocols_src_dir}/presentation-time-protocol.c"
     HEADER_FILE "${_wayland_protocols_src_dir}/presentation-time-protocol.h")
 
+  generate_wayland_client_protocol(
+    PROTOCOL_FILE "${_wayland_protocols_xml_dir}/unstable/xdg-decoration/xdg-decoration-unstable-v1.xml"
+    CODE_FILE "${_wayland_protocols_src_dir}/xdg-decoration-unstable-v1-protocol.c"
+    HEADER_FILE "${_wayland_protocols_src_dir}/xdg-decoration-unstable-v1-protocol.h")
+
   add_definitions(-DFLUTTER_TARGET_BACKEND_WAYLAND)
   add_definitions(-DDISPLAY_BACKEND_TYPE_WAYLAND)
   set(DISPLAY_BACKEND_SRC
@@ -70,6 +75,7 @@ else()
     "${_wayland_protocols_src_dir}/text-input-unstable-v1-protocol.c"
     "${_wayland_protocols_src_dir}/text-input-unstable-v3-protocol.c"
     "${_wayland_protocols_src_dir}/presentation-time-protocol.c"
+    "${_wayland_protocols_src_dir}/xdg-decoration-unstable-v1-protocol.c"
     "src/flutter/shell/platform/linux_embedded/window/elinux_window_wayland.cc"
     "src/flutter/shell/platform/linux_embedded/window/native_window_wayland.cc"
     "src/flutter/shell/platform/linux_embedded/window/native_window_wayland_decoration.cc"

--- a/src/flutter/shell/platform/linux_embedded/window/elinux_window_wayland.h
+++ b/src/flutter/shell/platform/linux_embedded/window/elinux_window_wayland.h
@@ -25,6 +25,7 @@ extern "C" {
 #include "wayland/protocols/text-input-unstable-v1-client-protocol.h"
 #include "wayland/protocols/text-input-unstable-v3-client-protocol.h"
 #include "wayland/protocols/xdg-shell-client-protocol.h"
+#include "wayland/protocols/xdg-decoration-unstable-v1-protocol.h"
 }
 
 namespace flutter {
@@ -170,6 +171,10 @@ class ELinuxWindowWayland : public ELinuxWindow, public WindowBindingHandler {
   zwp_text_input_manager_v3* zwp_text_input_manager_v3_;
   zwp_text_input_v1* zwp_text_input_v1_;
   zwp_text_input_v3* zwp_text_input_v3_;
+
+  // xdg-decoration for server-side decorations
+  zxdg_decoration_manager_v1* decoration_manager_;
+  zxdg_toplevel_decoration_v1* xdg_toplevel_decoration_;
 
   // Frame information for Vsync events.
   wp_presentation* wp_presentation_;


### PR DESCRIPTION
Hello @HidenoriMatsubayashi and other maintainers,

I wanted xdg-decoration support in flutter-embedded-linux and thus i worked on it and added support for it.

Relevant issue: https://github.com/sony/flutter-embedded-linux/issues/216

I just want this to be merged. I don't even need the authorship right of this commit. Please merge this commit if there are no issues with the code.