### PR TITLE
Add support EGLImage-based texture

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -9,3 +9,4 @@ Hidenori Matsubayashi (hidenori.matsubayashi@gmail.com)
 Andrea Daoud (andreadaoud6@gmail.com)
 Valentin Hăloiu (valentin.haloiu@gmail.com)
 FlafyDev <flafyarazi@gmail.com>
+Makoto Sato (makoto.sato@atmark-techno.com)

--- a/cmake/build.cmake
+++ b/cmake/build.cmake
@@ -136,6 +136,7 @@ set(ELINUX_COMMON_SRC
   "src/flutter/shell/platform/linux_embedded/system_utils.cc"
   "src/flutter/shell/platform/linux_embedded/logger.cc"
   "src/flutter/shell/platform/linux_embedded/external_texture_pixelbuffer.cc"
+  "src/flutter/shell/platform/linux_embedded/external_texture_egl_image.cc"
   "src/flutter/shell/platform/linux_embedded/vsync_waiter.cc"
   "src/flutter/shell/platform/linux_embedded/flutter_elinux_texture_registrar.cc"
   "src/flutter/shell/platform/linux_embedded/plugins/keyboard_glfw_util.cc"

--- a/src/flutter/shell/platform/common/client_wrapper/core_implementations.cc
+++ b/src/flutter/shell/platform/common/client_wrapper/core_implementations.cc
@@ -180,6 +180,15 @@ int64_t TextureRegistrarImpl::RegisterTexture(TextureVariant* texture) {
       auto texture = static_cast<GpuSurfaceTexture*>(user_data);
       return texture->ObtainDescriptor(width, height);
     };
+  } else if (auto egl_image_texture = std::get_if<EGLImageTexture>(texture)) {
+    info.type = kFlutterDesktopEGLImageTexture;
+    info.egl_image_config.user_data = egl_image_texture;
+    info.egl_image_config.callback =
+        [](size_t width, size_t height, void* egl_display, void* egl_context,
+           void* user_data) -> const FlutterDesktopEGLImage* {
+      auto texture = static_cast<EGLImageTexture*>(user_data);
+      return texture->GetEGLImage(width, height, egl_display, egl_context);
+    };
   } else {
     std::cerr << "Attempting to register unknown texture variant." << std::endl;
     return -1;

--- a/src/flutter/shell/platform/common/public/flutter_texture_registrar.h
+++ b/src/flutter/shell/platform/common/public/flutter_texture_registrar.h
@@ -25,7 +25,9 @@ typedef enum {
   // A Pixel buffer-based texture.
   kFlutterDesktopPixelBufferTexture,
   // A platform-specific GPU surface-backed texture.
-  kFlutterDesktopGpuSurfaceTexture
+  kFlutterDesktopGpuSurfaceTexture,
+  // An EGLImage-based texture
+  kFlutterDesktopEGLImageTexture
 } FlutterDesktopTextureType;
 
 // Supported GPU surface types.
@@ -65,6 +67,20 @@ typedef struct {
   // Opaque data passed to |release_callback|.
   void* release_context;
 } FlutterDesktopPixelBuffer;
+
+// An EGLImage object.
+typedef struct {
+  // The EGLImage object.(opaque)
+  const void* egl_image;
+  // Width of the EGLImage.
+  size_t width;
+  // Height of the EGLImage.
+  size_t height;
+  // An optional callback that gets invoked when the |egl_image| can be released.
+  void (*release_callback)(void* release_context);
+  // Opaque data passed to |release_callback|.
+  void* release_context;
+} FlutterDesktopEGLImage;
 
 // A GPU surface descriptor.
 typedef struct {
@@ -126,6 +142,13 @@ typedef const FlutterDesktopGpuSurfaceDescriptor* (
                                               size_t height,
                                               void* user_data);
 
+typedef const FlutterDesktopEGLImage* (
+    *FlutterDesktopEGLImageTextureCallback)(size_t width,
+                                            size_t height,
+                                            void* egl_display,
+                                            void* egl_context,
+                                            void* user_data);
+
 // An object used to configure pixel buffer textures.
 typedef struct {
   // The callback used by the engine to copy the pixel buffer object.
@@ -148,11 +171,20 @@ typedef struct {
   void* user_data;
 } FlutterDesktopGpuSurfaceTextureConfig;
 
+// An object used to configure EGLImage textures.
+typedef struct {
+  // The callback used by the engine to get the EGLImage object.
+  FlutterDesktopEGLImageTextureCallback callback;
+  // Opaque data that will get passed to the provided |callback|.
+  void* user_data;
+} FlutterDesktopEGLImageTextureConfig;
+
 typedef struct {
   FlutterDesktopTextureType type;
   union {
     FlutterDesktopPixelBufferTextureConfig pixel_buffer_config;
     FlutterDesktopGpuSurfaceTextureConfig gpu_surface_config;
+    FlutterDesktopEGLImageTextureConfig egl_image_config;
   };
 } FlutterDesktopTextureInfo;
 

--- a/src/flutter/shell/platform/linux_embedded/external_texture.h
+++ b/src/flutter/shell/platform/linux_embedded/external_texture.h
@@ -29,6 +29,8 @@ typedef void (*glTexImage2DProc)(GLenum target,
                                  GLenum format,
                                  GLenum type,
                                  const void* data);
+typedef void (*glEGLImageTargetTexture2DOESProc)(GLenum target,
+                                                 GLeglImageOES image);
 
 // A struct containing pointers to resolved gl* functions.
 struct GlProcs {
@@ -37,6 +39,7 @@ struct GlProcs {
   glBindTextureProc glBindTexture;
   glTexParameteriProc glTexParameteri;
   glTexImage2DProc glTexImage2D;
+  glEGLImageTargetTexture2DOESProc glEGLImageTargetTexture2DOES;
   bool valid;
 };
 

--- a/src/flutter/shell/platform/linux_embedded/external_texture_egl_image.cc
+++ b/src/flutter/shell/platform/linux_embedded/external_texture_egl_image.cc
@@ -1,0 +1,89 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/shell/platform/linux_embedded/external_texture_egl_image.h"
+#include <EGL/egl.h>
+#include <EGL/eglext.h>
+
+namespace flutter {
+
+struct ExternalTextureEGLImageState {
+  GLuint gl_texture = 0;
+};
+
+ExternalTextureEGLImage::ExternalTextureEGLImage(
+    FlutterDesktopEGLImageTextureCallback texture_callback,
+    void* user_data,
+    const GlProcs& gl_procs)
+    : state_(std::make_unique<ExternalTextureEGLImageState>()),
+      texture_callback_(texture_callback),
+      user_data_(user_data),
+      gl_(gl_procs) {}
+
+ExternalTextureEGLImage::~ExternalTextureEGLImage() {
+  if (state_->gl_texture != 0) {
+    gl_.glDeleteTextures(1, &state_->gl_texture);
+  }
+}
+
+bool ExternalTextureEGLImage::PopulateTexture(
+    size_t width,
+    size_t height,
+    FlutterOpenGLTexture* opengl_texture) {
+  if (!GetEGLImage(width, height, eglGetCurrentDisplay(),
+                   eglGetCurrentContext())) {
+    return false;
+  }
+
+  // Populate the texture object used by the engine.
+  opengl_texture->target = GL_TEXTURE_2D;
+  opengl_texture->name = state_->gl_texture;
+#ifdef USE_GLES3
+  opengl_texture->format = GL_RGBA8;
+#else
+  opengl_texture->format = GL_RGBA8_OES;
+#endif
+  opengl_texture->destruction_callback = nullptr;
+  opengl_texture->user_data = nullptr;
+  opengl_texture->width = width;
+  opengl_texture->height = height;
+
+  return true;
+}
+
+bool ExternalTextureEGLImage::GetEGLImage(size_t& width,
+                                          size_t& height,
+                                          void* egl_display,
+                                          void* egl_context) {
+  using namespace std;
+
+  const FlutterDesktopEGLImage* egl_image =
+      texture_callback_(width, height, egl_display, egl_context, user_data_);
+  if (!egl_image || !egl_image->egl_image) {
+    return false;
+  }
+  width = egl_image->width;
+  height = egl_image->height;
+
+  if (state_->gl_texture == 0) {
+    gl_.glGenTextures(1, &state_->gl_texture);
+
+    gl_.glBindTexture(GL_TEXTURE_2D, state_->gl_texture);
+    gl_.glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    gl_.glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    gl_.glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    gl_.glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+  } else {
+    gl_.glBindTexture(GL_TEXTURE_2D, state_->gl_texture);
+  }
+  gl_.glEGLImageTargetTexture2DOES(GL_TEXTURE_2D,
+                                   (EGLImageKHR)egl_image->egl_image);
+
+  if (egl_image->release_callback) {
+    egl_image->release_callback(egl_image->release_context);
+  }
+  return true;
+}
+
+}  // namespace flutter

--- a/src/flutter/shell/platform/linux_embedded/external_texture_egl_image.h
+++ b/src/flutter/shell/platform/linux_embedded/external_texture_egl_image.h
@@ -1,0 +1,54 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_SHELL_PLATFORM_LINUX_EMBEDDED_EXTERNAL_TEXTURE_EGL_IMAGE_H_
+#define FLUTTER_SHELL_PLATFORM_LINUX_EMBEDDED_EXTERNAL_TEXTURE_EGL_IMAGE_H_
+
+#include <stdint.h>
+
+#include <memory>
+
+#include "flutter/shell/platform/common/public/flutter_texture_registrar.h"
+
+#include "flutter/shell/platform/linux_embedded/external_texture.h"
+
+namespace flutter {
+
+typedef struct ExternalTextureEGLImageState ExternalTextureEGLImageState;
+
+// An abstraction of an EGL Image based texture.
+class ExternalTextureEGLImage : public ExternalTexture {
+ public:
+  ExternalTextureEGLImage(
+      FlutterDesktopEGLImageTextureCallback texture_callback,
+      void* user_data,
+      const GlProcs& gl_procs);
+
+  virtual ~ExternalTextureEGLImage();
+
+  // |ExternalTexture|
+  bool PopulateTexture(size_t width,
+                       size_t height,
+                       FlutterOpenGLTexture* opengl_texture) override;
+
+ private:
+  // Attempts to get the EGLImage returned by |texture_callback_| to
+  // OpenGL.
+  // The |width| and |height| will be set to the actual bounds of the EGLImage
+  // Returns true on success or false if the EGLImage returned
+  // by |texture_callback_| was invalid.
+  bool GetEGLImage(size_t& width,
+                   size_t& height,
+                   void* egl_display,
+                   void* egl_context);
+
+  std::unique_ptr<ExternalTextureEGLImageState> state_;
+  FlutterDesktopEGLImageTextureCallback texture_callback_ = nullptr;
+  void* const user_data_ = nullptr;
+  const GlProcs& gl_;
+};
+
+}  // namespace flutter
+
+#endif  // FLUTTER_SHELL_PLATFORM_LINUX_EMBEDDED_EXTERNAL_TEXTURE_EGL_IMAGE_H_


### PR DESCRIPTION
Hello.

I needed to add EGLImage-based texture support to flutter-embedded-linux to improve video_player playback performance.
So I added support.

Relevant issue: sony/flutter-elinux-plugins#64