### PR TITLE
Enhancements to initialization code in drm backend

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -10,3 +10,4 @@ Andrea Daoud (andreadaoud6@gmail.com)
 Valentin Hăloiu (valentin.haloiu@gmail.com)
 FlafyDev <flafyarazi@gmail.com>
 Makoto Sato (makoto.sato@atmark-techno.com)
+Yunhao Tian (t123yh@outlook.com)

--- a/src/flutter/shell/platform/linux_embedded/window/native_window_drm_gbm.cc
+++ b/src/flutter/shell/platform/linux_embedded/window/native_window_drm_gbm.cc
@@ -175,10 +175,14 @@ void NativeWindowDrmGbm::SwapBuffers() {
   if (result != 0) {
     ELINUX_LOG(ERROR) << "Failed to add a framebuffer. (" << result << ")";
   }
-  result = drmModeSetCrtc(drm_device_, drm_crtc_->crtc_id, fb, 0, 0,
-                          &drm_connector_id_, 1, &drm_mode_info_);
-  if (result != 0) {
-    ELINUX_LOG(ERROR) << "Failed to set crct mode. (" << result << ")";
+  if (!drm_crtc_) {
+    ELINUX_LOG(ERROR) << "crtc is null, cannot set mode.";
+  } else {
+    result = drmModeSetCrtc(drm_device_, drm_crtc_->crtc_id, fb, 0, 0,
+                            &drm_connector_id_, 1, &drm_mode_info_);
+    if (result != 0) {
+      ELINUX_LOG(ERROR) << "Failed to set crct mode. (" << result << ")";
+    }
   }
 
   if (gbm_previous_bo_) {


### PR DESCRIPTION
In RK3399 board running latest mainline kernel, when the system just booted up, there's no encoder attached to connector, and no crtc attached to encoder. In this case flutter-embedded will fail to start with error message `Couldn't find any encoders`. In this case, `modetest` will report the following:

```
Encoders:
id      crtc    type    possible crtcs  possible clones
38      0       DSI     0x00000001      0x00000001

Connectors:
id      encoder status          name            size (mm)       modes   encoders
39      0       connected       DSI-1           95x53           1       38
```

After the user run something like `glmark2-es2-drm`, they will get initialized, and flutter apps will work now:

```
Encoders:
id      crtc    type    possible crtcs  possible clones
38      37      DSI     0x00000001      0x00000001

Connectors:
id      encoder status          name            size (mm)       modes   encoders
39      38      connected       DSI-1           95x53           1       38
```

This PR adds code to find suitable encoder and crtc from drm resources structure when they are absent. After this is applied, flutter apps can run on boot, even without crtcs and encoders assigned to connector.

As an extra protection measure, this adds guard code against SIGSEGV in gbm backend, in case no crtc is initialized.