### PR TITLE
embedder: don't use reference params in C APIs (#345)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -11,3 +11,4 @@ Valentin Hăloiu (valentin.haloiu@gmail.com)
 FlafyDev <flafyarazi@gmail.com>
 Makoto Sato (makoto.sato@atmark-techno.com)
 Yunhao Tian (t123yh@outlook.com)
+Luke Howard <lukeh@padl.com>

--- a/src/client_wrapper/flutter_engine.cc
+++ b/src/client_wrapper/flutter_engine.cc
@@ -30,7 +30,7 @@ FlutterEngine::FlutterEngine(const DartProject& project) {
   c_engine_properties.dart_entrypoint_argv =
       entrypoint_argv.size() > 0 ? entrypoint_argv.data() : nullptr;
 
-  engine_ = FlutterDesktopEngineCreate(c_engine_properties);
+  engine_ = FlutterDesktopEngineCreate(&c_engine_properties);
 
   auto core_messenger = FlutterDesktopEngineGetMessenger(engine_);
   messenger_ = std::make_unique<BinaryMessengerImpl>(core_messenger);

--- a/src/client_wrapper/flutter_view_controller.cc
+++ b/src/client_wrapper/flutter_view_controller.cc
@@ -43,7 +43,7 @@ FlutterViewController::FlutterViewController(
   c_view_properties.force_scale_factor = view_properties.force_scale_factor;
   c_view_properties.scale_factor = view_properties.scale_factor;
 
-  controller_ = FlutterDesktopViewControllerCreate(c_view_properties,
+  controller_ = FlutterDesktopViewControllerCreate(&c_view_properties,
                                                    engine_->RelinquishEngine());
   if (!controller_) {
     std::cerr << "Failed to create view controller." << std::endl;

--- a/src/flutter/shell/platform/linux_embedded/flutter_elinux.cc
+++ b/src/flutter/shell/platform/linux_embedded/flutter_elinux.cc
@@ -72,21 +72,21 @@ uint64_t FlutterDesktopEngineProcessMessages(FlutterDesktopEngineRef engine) {
 }
 
 FlutterDesktopViewControllerRef FlutterDesktopViewControllerCreate(
-    const FlutterDesktopViewProperties& view_properties,
+    const FlutterDesktopViewProperties* view_properties,
     FlutterDesktopEngineRef engine) {
   std::unique_ptr<flutter::WindowBindingHandler> window_wrapper =
 
 #if defined(DISPLAY_BACKEND_TYPE_DRM_GBM)
       std::make_unique<flutter::ELinuxWindowDrm<flutter::NativeWindowDrmGbm>>(
-          view_properties);
+          *view_properties);
 #elif defined(DISPLAY_BACKEND_TYPE_DRM_EGLSTREAM)
       std::make_unique<
           flutter::ELinuxWindowDrm<flutter::NativeWindowDrmEglstream>>(
-          view_properties);
+          *view_properties);
 #elif defined(DISPLAY_BACKEND_TYPE_X11)
-      std::make_unique<flutter::ELinuxWindowX11>(view_properties);
+      std::make_unique<flutter::ELinuxWindowX11>(*view_properties);
 #else
-      std::make_unique<flutter::ELinuxWindowWayland>(view_properties);
+      std::make_unique<flutter::ELinuxWindowWayland>(*view_properties);
 #endif
 
   auto state = std::make_unique<FlutterDesktopViewControllerState>();
@@ -134,8 +134,8 @@ int32_t FlutterDesktopViewGetFrameRate(FlutterDesktopViewRef view) {
 }
 
 FlutterDesktopEngineRef FlutterDesktopEngineCreate(
-    const FlutterDesktopEngineProperties& engine_properties) {
-  flutter::FlutterProjectBundle project(engine_properties);
+    const FlutterDesktopEngineProperties* engine_properties) {
+  flutter::FlutterProjectBundle project(*engine_properties);
   auto engine = std::make_unique<flutter::FlutterELinuxEngine>(project);
   return HandleForEngine(engine.release());
 }

--- a/src/flutter/shell/platform/linux_embedded/public/flutter_elinux.h
+++ b/src/flutter/shell/platform/linux_embedded/public/flutter_elinux.h
@@ -128,7 +128,7 @@ typedef struct {
 // an error.
 FLUTTER_EXPORT FlutterDesktopViewControllerRef
 FlutterDesktopViewControllerCreate(
-    const FlutterDesktopViewProperties& view_properties,
+    const FlutterDesktopViewProperties* view_properties,
     FlutterDesktopEngineRef engine);
 
 // Shuts down the engine instance associated with |controller|, and cleans up
@@ -161,7 +161,7 @@ FlutterDesktopViewGetFrameRate(FlutterDesktopViewRef view);
 // The caller owns the returned reference, and is responsible for calling
 // FlutterDesktopEngineDestroy.
 FLUTTER_EXPORT FlutterDesktopEngineRef FlutterDesktopEngineCreate(
-    const FlutterDesktopEngineProperties& engine_properties);
+    const FlutterDesktopEngineProperties* engine_properties);
 
 // Shuts down and destroys the given engine instance. Returns true if the
 // shutdown was successful, or if the engine was not running.


### PR DESCRIPTION
flutter_elinux.h is a C API, so reference parameters are unavailable. Change FlutterDesktopViewControllerCreate() and FlutterDesktopEngineCreate() to instead take a pointer. Based fix for upstream issue (flutter/engine#25439).

```
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```