### PR TITLE
wayland: fix wrong height when using decoration option

### DIFF
--- a/src/flutter/shell/platform/linux_embedded/window/elinux_window_wayland.cc
+++ b/src/flutter/shell/platform/linux_embedded/window/elinux_window_wayland.cc
@@ -107,8 +107,7 @@ const xdg_toplevel_listener ELinuxWindowWayland::kXdgToplevelListener = {
           }
 
           int32_t next_width = width;
-          int32_t next_height =
-              height - self->WindowDecorationsPhysicalHeight();
+          int32_t next_height = height;
           if (self->restore_window_required_) {
             self->restore_window_required_ = false;
             next_width = self->restore_window_width_;


### PR DESCRIPTION
This change fixes a wrong height size when decoration ("-d") option is used.