### PR TITLE
wayland: fix layout is skewed issue when using decoration option

### DIFF
--- a/src/flutter/shell/platform/linux_embedded/window/elinux_window.h
+++ b/src/flutter/shell/platform/linux_embedded/window/elinux_window.h
@@ -40,6 +40,8 @@ class ELinuxWindow {
   }
 
   FlutterDesktopViewProperties view_properties_;
+  int32_t display_max_width_ = -1;
+  int32_t display_max_height_ = -1;
   double current_scale_ = 1.0;
   uint16_t current_rotation_ = 0;
   // The x coordinate of the pointer in physical pixels.


### PR DESCRIPTION
This change fixes the layout issue that is skewed when using decoration option.

<img width="1277" alt="スクリーンショット 2023-08-05 21 00 40" src="https://github.com/sony/flutter-embedded-linux/assets/62131389/2cc38c42-e39c-4b1c-bcd9-1bdaaa89f425">

Related PR #359