### PR TITLE
accessibility: add --enable-high-contrast option

### DIFF
--- a/examples/flutter-drm-eglstream-backend/flutter_embedder_options.h
+++ b/examples/flutter-drm-eglstream-backend/flutter_embedder_options.h
@@ -23,6 +23,9 @@ class FlutterEmbedderOptions {
                     false);
     options_.AddDouble("text-scaling-factor", "x", "Text scaling factor", 1.0,
                        false);
+    options_.AddWithoutValue("enable-high-contrast", "i",
+                             "Request that UI be rendered with darker colors.",
+                             false);
     options_.AddDouble("force-scale-factor", "s",
                        "Force a scale factor instead using default value", 1.0,
                        false);
@@ -86,6 +89,7 @@ class FlutterEmbedderOptions {
     }
 
     text_scale_factor_ = options_.GetValue<double>("text-scaling-factor");
+    enable_high_contrast_ = options_.Exist("enable-high-contrast");
 
     if (options_.Exist("force-scale-factor")) {
       is_force_scale_factor_ = true;
@@ -161,6 +165,9 @@ class FlutterEmbedderOptions {
   double TextScaleFactor() const {
     return text_scale_factor_;
   }
+  bool EnableHighContrast() const {
+    return enable_high_contrast_;
+  }
   bool IsForceScaleFactor() const {
     return is_force_scale_factor_;
   }
@@ -189,6 +196,7 @@ class FlutterEmbedderOptions {
   bool is_force_scale_factor_;
   double scale_factor_;
   double text_scale_factor_;
+  bool enable_high_contrast_;
   bool enable_vsync_;
 };
 

--- a/examples/flutter-drm-eglstream-backend/main.cc
+++ b/examples/flutter-drm-eglstream-backend/main.cc
@@ -36,6 +36,7 @@ int main(int argc, char** argv) {
   view_properties.use_onscreen_keyboard = options.IsUseOnscreenKeyboard();
   view_properties.use_window_decoration = options.IsUseWindowDecoraation();
   view_properties.text_scale_factor = options.TextScaleFactor();
+  view_properties.enable_high_contrast = options.EnableHighContrast();
   view_properties.force_scale_factor = options.IsForceScaleFactor();
   view_properties.scale_factor = options.ScaleFactor();
   view_properties.enable_vsync = options.EnableVsync();

--- a/examples/flutter-drm-gbm-backend/flutter_embedder_options.h
+++ b/examples/flutter-drm-gbm-backend/flutter_embedder_options.h
@@ -23,6 +23,9 @@ class FlutterEmbedderOptions {
                     false);
     options_.AddDouble("text-scaling-factor", "x", "Text scaling factor", 1.0,
                        false);
+    options_.AddWithoutValue("enable-high-contrast", "i",
+                             "Request that UI be rendered with darker colors.",
+                             false);
     options_.AddDouble("force-scale-factor", "s",
                        "Force a scale factor instead using default value", 1.0,
                        false);
@@ -86,6 +89,7 @@ class FlutterEmbedderOptions {
     }
 
     text_scale_factor_ = options_.GetValue<double>("text-scaling-factor");
+    enable_high_contrast_ = options_.Exist("enable-high-contrast");
 
     if (options_.Exist("force-scale-factor")) {
       is_force_scale_factor_ = true;
@@ -161,6 +165,9 @@ class FlutterEmbedderOptions {
   double TextScaleFactor() const {
     return text_scale_factor_;
   }
+  bool EnableHighContrast() const {
+    return enable_high_contrast_;
+  }
   bool IsForceScaleFactor() const {
     return is_force_scale_factor_;
   }
@@ -189,6 +196,7 @@ class FlutterEmbedderOptions {
   bool is_force_scale_factor_;
   double scale_factor_;
   double text_scale_factor_;
+  bool enable_high_contrast_;
   bool enable_vsync_;
 };
 

--- a/examples/flutter-drm-gbm-backend/main.cc
+++ b/examples/flutter-drm-gbm-backend/main.cc
@@ -36,6 +36,7 @@ int main(int argc, char** argv) {
   view_properties.use_onscreen_keyboard = options.IsUseOnscreenKeyboard();
   view_properties.use_window_decoration = options.IsUseWindowDecoraation();
   view_properties.text_scale_factor = options.TextScaleFactor();
+  view_properties.enable_high_contrast = options.EnableHighContrast();
   view_properties.force_scale_factor = options.IsForceScaleFactor();
   view_properties.scale_factor = options.ScaleFactor();
   view_properties.enable_vsync = options.EnableVsync();

--- a/examples/flutter-external-texture-plugin/flutter_embedder_options.h
+++ b/examples/flutter-external-texture-plugin/flutter_embedder_options.h
@@ -23,6 +23,9 @@ class FlutterEmbedderOptions {
                     false);
     options_.AddDouble("text-scaling-factor", "x", "Text scaling factor", 1.0,
                        false);
+    options_.AddWithoutValue("enable-high-contrast", "i",
+                             "Request that UI be rendered with darker colors.",
+                             false);
     options_.AddDouble("force-scale-factor", "s",
                        "Force a scale factor instead using default value", 1.0,
                        false);
@@ -86,6 +89,7 @@ class FlutterEmbedderOptions {
     }
 
     text_scale_factor_ = options_.GetValue<double>("text-scaling-factor");
+    enable_high_contrast_ = options_.Exist("enable-high-contrast");
 
     if (options_.Exist("force-scale-factor")) {
       is_force_scale_factor_ = true;
@@ -161,6 +165,9 @@ class FlutterEmbedderOptions {
   double TextScaleFactor() const {
     return text_scale_factor_;
   }
+  bool EnableHighContrast() const {
+    return enable_high_contrast_;
+  }
   bool IsForceScaleFactor() const {
     return is_force_scale_factor_;
   }
@@ -189,6 +196,7 @@ class FlutterEmbedderOptions {
   bool is_force_scale_factor_;
   double scale_factor_;
   double text_scale_factor_;
+  bool enable_high_contrast_;
   bool enable_vsync_;
 };
 

--- a/examples/flutter-external-texture-plugin/main.cc
+++ b/examples/flutter-external-texture-plugin/main.cc
@@ -36,6 +36,7 @@ int main(int argc, char** argv) {
   view_properties.use_onscreen_keyboard = options.IsUseOnscreenKeyboard();
   view_properties.use_window_decoration = options.IsUseWindowDecoraation();
   view_properties.text_scale_factor = options.TextScaleFactor();
+  view_properties.enable_high_contrast = options.EnableHighContrast();
   view_properties.force_scale_factor = options.IsForceScaleFactor();
   view_properties.scale_factor = options.ScaleFactor();
   view_properties.enable_vsync = options.EnableVsync();

--- a/examples/flutter-video-player-plugin/flutter_embedder_options.h
+++ b/examples/flutter-video-player-plugin/flutter_embedder_options.h
@@ -23,6 +23,9 @@ class FlutterEmbedderOptions {
                     false);
     options_.AddDouble("text-scaling-factor", "x", "Text scaling factor", 1.0,
                        false);
+    options_.AddWithoutValue("enable-high-contrast", "i",
+                             "Request that UI be rendered with darker colors.",
+                             false);
     options_.AddDouble("force-scale-factor", "s",
                        "Force a scale factor instead using default value", 1.0,
                        false);
@@ -86,6 +89,7 @@ class FlutterEmbedderOptions {
     }
 
     text_scale_factor_ = options_.GetValue<double>("text-scaling-factor");
+    enable_high_contrast_ = options_.Exist("enable-high-contrast");
 
     if (options_.Exist("force-scale-factor")) {
       is_force_scale_factor_ = true;
@@ -161,6 +165,9 @@ class FlutterEmbedderOptions {
   double TextScaleFactor() const {
     return text_scale_factor_;
   }
+  bool EnableHighContrast() const {
+    return enable_high_contrast_;
+  }
   bool IsForceScaleFactor() const {
     return is_force_scale_factor_;
   }
@@ -189,6 +196,7 @@ class FlutterEmbedderOptions {
   bool is_force_scale_factor_;
   double scale_factor_;
   double text_scale_factor_;
+  bool enable_high_contrast_;
   bool enable_vsync_;
 };
 

--- a/examples/flutter-video-player-plugin/main.cc
+++ b/examples/flutter-video-player-plugin/main.cc
@@ -36,6 +36,7 @@ int main(int argc, char** argv) {
   view_properties.use_onscreen_keyboard = options.IsUseOnscreenKeyboard();
   view_properties.use_window_decoration = options.IsUseWindowDecoraation();
   view_properties.text_scale_factor = options.TextScaleFactor();
+  view_properties.enable_high_contrast = options.EnableHighContrast();
   view_properties.force_scale_factor = options.IsForceScaleFactor();
   view_properties.scale_factor = options.ScaleFactor();
   view_properties.enable_vsync = options.EnableVsync();

--- a/examples/flutter-wayland-client/flutter_embedder_options.h
+++ b/examples/flutter-wayland-client/flutter_embedder_options.h
@@ -23,6 +23,9 @@ class FlutterEmbedderOptions {
                     false);
     options_.AddDouble("text-scaling-factor", "x", "Text scaling factor", 1.0,
                        false);
+    options_.AddWithoutValue("enable-high-contrast", "i",
+                             "Request that UI be rendered with darker colors.",
+                             false);
     options_.AddDouble("force-scale-factor", "s",
                        "Force a scale factor instead using default value", 1.0,
                        false);
@@ -86,6 +89,7 @@ class FlutterEmbedderOptions {
     }
 
     text_scale_factor_ = options_.GetValue<double>("text-scaling-factor");
+    enable_high_contrast_ = options_.Exist("enable-high-contrast");
 
     if (options_.Exist("force-scale-factor")) {
       is_force_scale_factor_ = true;
@@ -161,6 +165,9 @@ class FlutterEmbedderOptions {
   double TextScaleFactor() const {
     return text_scale_factor_;
   }
+  bool EnableHighContrast() const {
+    return enable_high_contrast_;
+  }
   bool IsForceScaleFactor() const {
     return is_force_scale_factor_;
   }
@@ -189,6 +196,7 @@ class FlutterEmbedderOptions {
   bool is_force_scale_factor_;
   double scale_factor_;
   double text_scale_factor_;
+  bool enable_high_contrast_;
   bool enable_vsync_;
 };
 

--- a/examples/flutter-wayland-client/main.cc
+++ b/examples/flutter-wayland-client/main.cc
@@ -36,6 +36,7 @@ int main(int argc, char** argv) {
   view_properties.use_onscreen_keyboard = options.IsUseOnscreenKeyboard();
   view_properties.use_window_decoration = options.IsUseWindowDecoraation();
   view_properties.text_scale_factor = options.TextScaleFactor();
+  view_properties.enable_high_contrast = options.EnableHighContrast();
   view_properties.force_scale_factor = options.IsForceScaleFactor();
   view_properties.scale_factor = options.ScaleFactor();
   view_properties.enable_vsync = options.EnableVsync();

--- a/examples/flutter-x11-client/flutter_embedder_options.h
+++ b/examples/flutter-x11-client/flutter_embedder_options.h
@@ -23,6 +23,9 @@ class FlutterEmbedderOptions {
                     false);
     options_.AddDouble("text-scaling-factor", "x", "Text scaling factor", 1.0,
                        false);
+    options_.AddWithoutValue("enable-high-contrast", "i",
+                             "Request that UI be rendered with darker colors.",
+                             false);
     options_.AddDouble("force-scale-factor", "s",
                        "Force a scale factor instead using default value", 1.0,
                        false);
@@ -86,6 +89,7 @@ class FlutterEmbedderOptions {
     }
 
     text_scale_factor_ = options_.GetValue<double>("text-scaling-factor");
+    enable_high_contrast_ = options_.Exist("enable-high-contrast");
 
     if (options_.Exist("force-scale-factor")) {
       is_force_scale_factor_ = true;
@@ -161,6 +165,9 @@ class FlutterEmbedderOptions {
   double TextScaleFactor() const {
     return text_scale_factor_;
   }
+  bool EnableHighContrast() const {
+    return enable_high_contrast_;
+  }
   bool IsForceScaleFactor() const {
     return is_force_scale_factor_;
   }
@@ -189,6 +196,7 @@ class FlutterEmbedderOptions {
   bool is_force_scale_factor_;
   double scale_factor_;
   double text_scale_factor_;
+  bool enable_high_contrast_;
   bool enable_vsync_;
 };
 

--- a/examples/flutter-x11-client/main.cc
+++ b/examples/flutter-x11-client/main.cc
@@ -36,6 +36,7 @@ int main(int argc, char** argv) {
   view_properties.use_onscreen_keyboard = options.IsUseOnscreenKeyboard();
   view_properties.use_window_decoration = options.IsUseWindowDecoraation();
   view_properties.text_scale_factor = options.TextScaleFactor();
+  view_properties.enable_high_contrast = options.EnableHighContrast();
   view_properties.force_scale_factor = options.IsForceScaleFactor();
   view_properties.scale_factor = options.ScaleFactor();
   view_properties.enable_vsync = options.EnableVsync();

--- a/src/client_wrapper/flutter_view_controller.cc
+++ b/src/client_wrapper/flutter_view_controller.cc
@@ -41,6 +41,7 @@ FlutterViewController::FlutterViewController(
   c_view_properties.use_window_decoration =
       view_properties.use_window_decoration;
   c_view_properties.text_scale_factor = view_properties.text_scale_factor;
+  c_view_properties.enable_high_contrast = view_properties.enable_high_contrast;
   c_view_properties.force_scale_factor = view_properties.force_scale_factor;
   c_view_properties.scale_factor = view_properties.scale_factor;
   c_view_properties.enable_vsync = view_properties.enable_vsync;

--- a/src/client_wrapper/include/flutter/flutter_view_controller.h
+++ b/src/client_wrapper/include/flutter/flutter_view_controller.h
@@ -79,6 +79,9 @@ class FlutterViewController {
     // Text scaling factor.
     double text_scale_factor;
 
+    // Enable high contrast. Request that UI be rendered with darker colors.
+    bool enable_high_contrast;
+
     // Force scale factor specified by command line argument
     bool force_scale_factor;
     double scale_factor;

--- a/src/flutter/shell/platform/linux_embedded/flutter_elinux.cc
+++ b/src/flutter/shell/platform/linux_embedded/flutter_elinux.cc
@@ -102,7 +102,8 @@ FlutterDesktopViewControllerRef FlutterDesktopViewControllerCreate(
     }
 
     const float text_scaling_factor = view_properties->text_scale_factor;
-    state->view->GetEngine()->SetSystemSettings(text_scaling_factor);
+    state->view->GetEngine()->SetSystemSettings(
+        text_scaling_factor, view_properties->enable_high_contrast);
   }
 
   // Must happen after engine is running.

--- a/src/flutter/shell/platform/linux_embedded/flutter_elinux_engine.cc
+++ b/src/flutter/shell/platform/linux_embedded/flutter_elinux_engine.cc
@@ -379,12 +379,10 @@ void FlutterELinuxEngine::ReloadSystemFonts() {
   embedder_api_.ReloadSystemFonts(engine_);
 }
 
-void FlutterELinuxEngine::SetSystemSettings(float text_scaling_factor) {
+void FlutterELinuxEngine::SetSystemSettings(float text_scaling_factor,
+                                            bool enable_high_contrast) {
   view_->UpdateTextScaleFactor(text_scaling_factor);
-
-  // TODO: add theme initial value support.
-  view_->UpdateHighContrastEnabled(false);
-
+  view_->UpdateHighContrastEnabled(enable_high_contrast);
   SendSystemLocales();
 }
 
@@ -435,6 +433,11 @@ void FlutterELinuxEngine::OnVsync(uint64_t last_frame_time_nanos,
 
   vsync_waiter_->NotifyVsync(engine_, &embedder_api_, frame_start_time_nanos,
                              frame_target_time_nanos);
+}
+
+void FlutterELinuxEngine::UpdateAccessibilityFeatures(
+    FlutterAccessibilityFeature flags) {
+  embedder_api_.UpdateAccessibilityFeatures(engine_, flags);
 }
 
 }  // namespace flutter

--- a/src/flutter/shell/platform/linux_embedded/flutter_elinux_engine.h
+++ b/src/flutter/shell/platform/linux_embedded/flutter_elinux_engine.h
@@ -128,7 +128,10 @@ class FlutterELinuxEngine {
   bool IsImpellerEnabled() const { return enable_impeller_; }
 
   // Sets system settings.
-  void SetSystemSettings(float text_scaling_factor);
+  void SetSystemSettings(float text_scaling_factor, bool enable_high_contrast);
+
+  // Updates accessibility, e.g. switch to high contrast mode
+  void UpdateAccessibilityFeatures(FlutterAccessibilityFeature flags);
 
  private:
   // Allows swapping out embedder_api_ calls in tests.

--- a/src/flutter/shell/platform/linux_embedded/flutter_elinux_view.cc
+++ b/src/flutter/shell/platform/linux_embedded/flutter_elinux_view.cc
@@ -506,7 +506,16 @@ std::pair<double, double> FlutterELinuxView::GetPointerRotation(double x_px,
 }
 
 void FlutterELinuxView::UpdateHighContrastEnabled(bool enabled) {
-  // TODO: add UpdateAccessibilityFeatures support
+  int flags = 0;
+  if (enabled) {
+    flags |=
+        FlutterAccessibilityFeature::kFlutterAccessibilityFeatureHighContrast;
+  } else {
+    flags &=
+        ~FlutterAccessibilityFeature::kFlutterAccessibilityFeatureHighContrast;
+  }
+  engine_.get()->UpdateAccessibilityFeatures(
+      static_cast<FlutterAccessibilityFeature>(flags));
   settings_handler_->UpdateHighContrastMode(enabled);
 }
 

--- a/src/flutter/shell/platform/linux_embedded/plugins/settings_plugin.cc
+++ b/src/flutter/shell/platform/linux_embedded/plugins/settings_plugin.cc
@@ -45,8 +45,13 @@ void SettingsPlugin::SendSettings() {
 }
 
 bool SettingsPlugin::GetAlwaysUse24HourFormat() {
-  // The current OS does not have 24 hour format factor.
-  return true;
+  return is_always_use_24hour_format_;
+}
+
+void SettingsPlugin::UpdateAlwaysUse24HourFormat(
+    bool is_always_use_24hour_format) {
+  is_always_use_24hour_format_ = is_always_use_24hour_format;
+  SendSettings();
 }
 
 float SettingsPlugin::GetTextScaleFactor() {

--- a/src/flutter/shell/platform/linux_embedded/plugins/settings_plugin.h
+++ b/src/flutter/shell/platform/linux_embedded/plugins/settings_plugin.h
@@ -31,6 +31,9 @@ class SettingsPlugin {
   // Sends settings (e.g., platform brightness) to the engine.
   void SendSettings();
 
+  // Update the always use 24hour-format status of the system.
+  void UpdateAlwaysUse24HourFormat(bool is_always_use_24hour_format);
+
   // Update the high contrast status of the system.
   void UpdateHighContrastMode(bool is_high_contrast);
 
@@ -50,6 +53,7 @@ class SettingsPlugin {
   std::unique_ptr<BasicMessageChannel<rapidjson::Document>> channel_;
   WindowBindingHandler* delegate_;
   bool is_high_contrast_ = false;
+  bool is_always_use_24hour_format_ = true;
   float text_scaling_factor_ = 1.0;
 };
 

--- a/src/flutter/shell/platform/linux_embedded/public/flutter_elinux.h
+++ b/src/flutter/shell/platform/linux_embedded/public/flutter_elinux.h
@@ -109,6 +109,9 @@ typedef struct {
   // Text scaling factor.
   double text_scale_factor;
 
+  // Enable high contrast. Request that UI be rendered with darker colors.
+  bool enable_high_contrast;
+
   // Force scale factor specified by command line argument
   bool force_scale_factor;
   double scale_factor;


### PR DESCRIPTION
This change add "--enable-high-contrast" command-line option to request that UI be rendered with darker colors.

Related issues #2, #168