### PR TITLE
common: fix syntax error in event_channel.h

### DIFF
--- a/src/flutter/shell/platform/common/client_wrapper/include/flutter/event_channel.h
+++ b/src/flutter/shell/platform/common/client_wrapper/include/flutter/event_channel.h
@@ -92,7 +92,7 @@ class EventChannel {
                 std::cerr << "Failed to cancel existing stream: "
                           << (error->error_code) << ", "
                           << (error->error_message) << ", "
-                          << (error->error_details);
+                          << (error->error_details.get());
               }
             }
             is_listening = true;


### PR DESCRIPTION
This change fixes the following build error in event_channel.h.

```
/home/hidenori/work/flutter/flutter-elinux-plugins/packages/camera/example/elinux/flutter/ephemeral/cpp_client_wrapper/include/flutter/e vent_channel.h:95:27: error: invalid operands to binary expression ('basic_ostream<char, std::char_traits<char>>' and 'const std::unique_ptr<EncodableValue>')
                          << (error->error_details);
                          ^  ~~~~~~~~~~~~~~~~~~~~~~
/home/hidenori/work/flutter/flutter-elinux-plugins/packages/camera/example/elinux/flutter/ephemeral/.plugin_symlinks/camera_elinux/elinu x/channels/event_channel_image_stream.cc:44:18: note: in instantiation of member function 'flutter::EventChannel<>::SetStreamHandler' requested here
  event_channel->SetStreamHandler(std::move(event_channel_handler));
                 ^
/usr/bin/../lib/gcc/aarch64-linux-gnu/11/../../../../include/c++/11/system_error:279:5: note: candidate function template not viable: no known conversion from 'const std::unique_ptr<EncodableValue>' to 'const std::error_code' for 2nd argument
    operator<<(basic_ostream<_CharT, _Traits>& __os, const error_code& __e)
    ^
/usr/bin/../lib/gcc/aarch64-linux-gnu/11/../../../../include/c++/11/ostream:518:5: note: candidate function template not viable: no known conversion from 'const std::unique_ptr<EncodableValue>' to 'char' for 2nd argument
    operator<<(basic_ostream<_CharT, _Traits>& __out, char __c)
```
