### PR TITLE
github-actions: update actions/checkout from v2 to v3

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Install libraries
       run: |


### PR DESCRIPTION
This change updates actions/checkout version from v2 to v3.