### PR TITLE
engine: engine: disable fbo_reset_after_present to avoid flicker issues on some H/W

### DIFF
--- a/src/flutter/shell/platform/linux_embedded/flutter_elinux_engine.cc
+++ b/src/flutter/shell/platform/linux_embedded/flutter_elinux_engine.cc
@@ -42,7 +42,10 @@ FlutterRendererConfig GetRendererConfig() {
     }
     return host->view()->ClearCurrent();
   };
-  config.open_gl.fbo_reset_after_present = true;
+  // Temporary disabled fbo_reset_after_present to avoid flicker and other
+  // rendering issues on some H/W. See
+  // https://github.com/sony/flutter-embedded-linux/issues/334
+  config.open_gl.fbo_reset_after_present = false;
 #if defined(USE_OPENGL_DIRTY_REGION_MANAGEMENT)
   config.open_gl.present_with_info =
       [](void* user_data, const FlutterPresentInfo* info) -> bool {


### PR DESCRIPTION
Related issue https://github.com/sony/flutter-embedded-linux/issues/334

cc @makotosato-at 