### PR TITLE
Revert "engine: disable fbo_reset_after_present to avoid flicker issues on some H/W (#385)"

### DIFF
--- a/src/flutter/shell/platform/linux_embedded/flutter_elinux_engine.cc
+++ b/src/flutter/shell/platform/linux_embedded/flutter_elinux_engine.cc
@@ -42,10 +42,7 @@ FlutterRendererConfig GetRendererConfig() {
     }
     return host->view()->ClearCurrent();
   };
-  // Temporary disabled fbo_reset_after_present to avoid flicker and other
-  // rendering issues on some H/W. See
-  // https://github.com/sony/flutter-embedded-linux/issues/334
-  config.open_gl.fbo_reset_after_present = false;
+  config.open_gl.fbo_reset_after_present = true;
 #if defined(USE_OPENGL_DIRTY_REGION_MANAGEMENT)
   config.open_gl.present_with_info =
       [](void* user_data, const FlutterPresentInfo* info) -> bool {


### PR DESCRIPTION
This reverts commit 6d652df06f94ffd42bd330bde9d77971db92985e.

Related issue #334