### PR TITLE
WAR: temporarily disable partial repaints

### DIFF
--- a/src/flutter/shell/platform/linux_embedded/surface/elinux_egl_surface.cc
+++ b/src/flutter/shell/platform/linux_embedded/surface/elinux_egl_surface.cc
@@ -168,6 +168,11 @@ void ELinuxEGLSurface::PopulateExistingDamage(const intptr_t fbo_id,
       0, 0, static_cast<double>(width_px_), static_cast<double>(height_px_)};
   existing_damage->damage = existing_damage_map_[fbo_id];
 
+  // Temporarily disabled partial repaints due to
+  // https://github.com/sony/flutter-embedded-linux/issues/334. Once
+  // https://github.com/flutter/engine/pull/45611 was merged and propagated to
+  // the stable channel, this will be lifted up.
+#if 0
   if (age > 1) {
     --age;
     // join up to (age - 1) last rects from damage history
@@ -191,6 +196,7 @@ void ELinuxEGLSurface::PopulateExistingDamage(const intptr_t fbo_id,
       }
     }
   }
+#endif
 }
 
 // Auxiliary function used to transform a FlutterRect into the format that is


### PR DESCRIPTION
This change disables the partial repaints temporarily because of the flicker issue. Once the root cause in flutter/engine was fixed and its change propagated to the stable channel, this will be lifted up.

See https://github.com/sony/flutter-embedded-linux/issues/334 for the details.