### PR TITLE
egl_stream: add cast to EGLAttrib

### DIFF
--- a/src/flutter/shell/platform/linux_embedded/surface/context_egl_stream.cc
+++ b/src/flutter/shell/platform/linux_embedded/surface/context_egl_stream.cc
@@ -28,7 +28,7 @@ std::unique_ptr<ELinuxEGLSurface> ContextEglStream::CreateOnscreenSurface(
   EGLOutputLayerEXT layer;
   EGLAttrib layer_attribs[] = {
       // clang-format off
-      EGL_DRM_PLANE_EXT, static_cast<NativeWindowDrmEglstream*>(window)->PlaneId(),
+      EGL_DRM_PLANE_EXT, static_cast<EGLAttrib>(static_cast<NativeWindowDrmEglstream*>(window)->PlaneId()),
       EGL_NONE
       // clang-format on
   };


### PR DESCRIPTION
Hello.

I'm trying to build for armhf.
In the process, I met the following errors.
```
context_egl_stream.cc:31:26: error: non-constant-expression cannot be narrowed from type 'uint32_t' (aka 'unsigned int') to 'EGLAttrib' (aka 'int') in initializer list [-Wc++11-narrowing]
      EGL_DRM_PLANE_EXT, static_cast<NativeWindowDrmEglstream*>(window)->PlaneId(),
                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
context_egl_stream.cc:31:26: note: insert an explicit cast to silence this issue
      EGL_DRM_PLANE_EXT, static_cast<NativeWindowDrmEglstream*>(window)->PlaneId(),
                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                         static_cast<EGLAttrib>(                                  )
1 error generated.
```

So I added a cast.