### PR TITLE
WAR: disable USE_DIRTY_REGION_MANAGEMENT option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,10 +11,13 @@ project("flutter_elinux" LANGUAGES CXX C)
 
 # Build options.
 option(BACKEND_TYPE "Select WAYLAND, DRM-GBM, DRM-EGLSTREAM, or X11 as the display backend type" WAYLAND)
-option(USE_DIRTY_REGION_MANAGEMENT "Use Flutter dirty region management" ON)
+# Disabled USE_DIRTY_REGION_MANAGEMENT due flicker issue.
+# See https://github.com/sony/flutter-embedded-linux/issues/334
+option(USE_DIRTY_REGION_MANAGEMENT "Use Flutter dirty region management" OFF)
 option(USE_GLES3 "Use OpenGL ES3 (default is OpenGL ES2)" OFF)
 option(ENABLE_EGL_ALPHA_COMPONENT_OF_COLOR_BUFFER "Enable alpha component of the EGL color buffer" ON)
-option(ENABLE_VSYNC "Enable embedder vsync" OFF) # todo: need to investigate https://github.com/sony/flutter-embedded-linux/pull/376 when enabling this option.
+ # todo: need to investigate https://github.com/sony/flutter-embedded-linux/pull/376 when enabling this option.
+option(ENABLE_VSYNC "Enable embedder vsync" OFF)
 option(BUILD_ELINUX_SO "Build .so file of elinux embedder" OFF)
 option(ENABLE_ELINUX_EMBEDDER_LOG "Enable logger of eLinux embedder" ON)
 option(FLUTTER_RELEASE "Build Flutter Engine with release mode" OFF)


### PR DESCRIPTION
This change disables 'dirty-region-management' feature to prevent a fricker issue. See #334 for the details.