### PR TITLE
Pointer not being drawn on second vnc connection

### DIFF
--- a/src/flutter/shell/platform/linux_embedded/window/elinux_window_wayland.h
+++ b/src/flutter/shell/platform/linux_embedded/window/elinux_window_wayland.h
@@ -171,6 +171,7 @@ class ELinuxWindowWayland : public ELinuxWindow, public WindowBindingHandler {
   wl_output* wl_output_;
   wl_shm* wl_shm_;
   std::unordered_map<wl_seat*, seat_inputs> seat_inputs_map_;
+  std::unordered_map<uint32_t, wl_seat*> registry_names_to_seat_ptr_;
   wl_surface* wl_cursor_surface_;
   xdg_wm_base* xdg_wm_base_;
   xdg_surface* xdg_surface_;


### PR DESCRIPTION
Fix pointer not being drawn on second VNC connect.
Use global_remove event to clean-up seat map.