### PR TITLE
Ensure FlutterDesktopViewControllerState declares default destructor

### DIFF
--- a/src/flutter/shell/platform/linux_embedded/flutter_elinux_state.h
+++ b/src/flutter/shell/platform/linux_embedded/flutter_elinux_state.h
@@ -34,6 +34,8 @@ struct FlutterELinuxView;
 struct FlutterDesktopViewControllerState {
   // The view that backs this state object.
   std::unique_ptr<flutter::FlutterELinuxView> view;
+
+  ~FlutterDesktopViewControllerState() = default;
 };
 
 // Wrapper to distinguish the plugin registrar ref from the engine ref given out


### PR DESCRIPTION
types containing std::unique_ptr to incomplete types require a destructor to be defined as the size is unavailable, otherwise the following error is raised at compile time:

```
/usr/lib/gcc/aarch64-linux-gnu/13/../../../../include/c++/13/bits/unique_ptr.h:97:16: error: invalid application of 'sizeof' to an incomplete type 'flutter::FlutterELinuxView'
  91 |       _GLIBCXX23_CONSTEXPR
  92 |       void
  93 |       operator()(_Tp* __ptr) const
     |       `- note: in instantiation of member function 'std::default_delete<flutter::FlutterELinuxView>::operator()' requested here
  94 |       {
  95 | 	static_assert(!is_void<_Tp>::value,
  96 | 		      "can't delete pointer to incomplete type");
  97 | 	static_assert(sizeof(_Tp)>0,
     |                `- error: invalid application of 'sizeof' to an incomplete type 'flutter::FlutterELinuxView'
  98 | 		      "can't delete pointer to incomplete type");
  99 | 	delete __ptr;
```