### PR TITLE
Mark FlutterELinuxEngine as an unsafe reference for importing into Swift

### DIFF
--- a/src/flutter/shell/platform/common/client_wrapper/include/flutter/texture_registrar.h
+++ b/src/flutter/shell/platform/common/client_wrapper/include/flutter/texture_registrar.h
@@ -136,7 +136,7 @@ class TextureRegistrar {
   // Unregisters an existing texture object.
   // DEPRECATED: Use UnregisterTexture(texture_id, optional_callback) instead.
   virtual bool UnregisterTexture(int64_t texture_id) = 0;
-};
+} SWIFT_UNSAFE_REFERENCE;
 
 }  // namespace flutter
 

--- a/src/flutter/shell/platform/common/public/flutter_export.h
+++ b/src/flutter/shell/platform/common/public/flutter_export.h
@@ -25,4 +25,13 @@
 
 #endif  // FLUTTER_DESKTOP_LIBRARY
 
+#if __has_include(<swift/bridging>)
+#include <swift/bridging>
+#else
+#define SWIFT_UNSAFE_REFERENCE
+#define SWIFT_SHARED_REFERENCE(_retain, _release)
+#define SWIFT_RETURNS_RETAINED
+#define SWIFT_RETURNS_UNRETAINED
+#endif
+
 #endif  // FLUTTER_SHELL_PLATFORM_COMMON_PUBLIC_FLUTTER_EXPORT_H_

--- a/src/flutter/shell/platform/common/public/flutter_messenger.h
+++ b/src/flutter/shell/platform/common/public/flutter_messenger.h
@@ -93,8 +93,8 @@ FLUTTER_EXPORT void FlutterDesktopMessengerSetCallback(
 // Operation is thread-safe.
 //
 // See also: |FlutterDesktopMessengerRelease|
-FLUTTER_EXPORT FlutterDesktopMessengerRef
-FlutterDesktopMessengerAddRef(FlutterDesktopMessengerRef messenger);
+FLUTTER_EXPORT FlutterDesktopMessengerRef FlutterDesktopMessengerAddRef(
+    FlutterDesktopMessengerRef messenger) SWIFT_RETURNS_RETAINED;
 
 // Decrements the reference count for the |messenger|.
 //
@@ -124,8 +124,8 @@ FLUTTER_EXPORT bool FlutterDesktopMessengerIsAvailable(
 // Returns the |messenger| value.
 //
 // See also: |FlutterDesktopMessengerUnlock|
-FLUTTER_EXPORT FlutterDesktopMessengerRef
-FlutterDesktopMessengerLock(FlutterDesktopMessengerRef messenger);
+FLUTTER_EXPORT FlutterDesktopMessengerRef FlutterDesktopMessengerLock(
+    FlutterDesktopMessengerRef messenger) SWIFT_RETURNS_UNRETAINED;
 
 // Unlocks the `FlutterDesktopMessengerRef`.
 //

--- a/src/flutter/shell/platform/common/public/flutter_plugin_registrar.h
+++ b/src/flutter/shell/platform/common/public/flutter_plugin_registrar.h
@@ -26,7 +26,7 @@ typedef void (*FlutterDesktopOnPluginRegistrarDestroyed)(
 // Returns the engine messenger associated with this registrar.
 FLUTTER_EXPORT FlutterDesktopMessengerRef
 FlutterDesktopPluginRegistrarGetMessenger(
-    FlutterDesktopPluginRegistrarRef registrar);
+    FlutterDesktopPluginRegistrarRef registrar) SWIFT_RETURNS_UNRETAINED;
 
 // Returns the texture registrar associated with this registrar.
 FLUTTER_EXPORT FlutterDesktopTextureRegistrarRef

--- a/src/flutter/shell/platform/linux_embedded/flutter_elinux_engine.h
+++ b/src/flutter/shell/platform/linux_embedded/flutter_elinux_engine.h
@@ -71,7 +71,9 @@ class FlutterELinuxEngine {
   // Sets switches member to the given switches.
   void SetSwitches(const std::vector<std::string>& switches);
 
-  FlutterDesktopMessengerRef messenger() { return messenger_.get(); }
+  FlutterDesktopMessengerRef messenger() SWIFT_RETURNS_UNRETAINED {
+    return messenger_.get();
+  }
 
   IncomingMessageDispatcher* message_dispatcher() {
     return message_dispatcher_.get();
@@ -195,7 +197,7 @@ class FlutterELinuxEngine {
   std::unique_ptr<VsyncWaiter> vsync_waiter_;
 
   bool enable_impeller_ = false;
-};
+} SWIFT_UNSAFE_REFERENCE;
 
 }  // namespace flutter
 

--- a/src/flutter/shell/platform/linux_embedded/flutter_elinux_state.h
+++ b/src/flutter/shell/platform/linux_embedded/flutter_elinux_state.h
@@ -9,12 +9,6 @@
 #include <memory>
 #include <mutex>
 
-#if __has_include(<swift/bridging>)
-#include <swift/bridging>
-#else
-#define SWIFT_SHARED_REFERENCE(_retain, _release)
-#endif
-
 #include "flutter/shell/platform/common/client_wrapper/include/flutter/plugin_registrar.h"
 #include "flutter/shell/platform/common/incoming_message_dispatcher.h"
 #include "flutter/shell/platform/embedder/embedder.h"

--- a/src/flutter/shell/platform/linux_embedded/flutter_elinux_texture_registrar.h
+++ b/src/flutter/shell/platform/linux_embedded/flutter_elinux_texture_registrar.h
@@ -56,7 +56,7 @@ class FlutterELinuxTextureRegistrar {
   std::mutex map_mutex_;
 
   int64_t EmplaceTexture(std::unique_ptr<ExternalTexture> texture);
-};
+} SWIFT_UNSAFE_REFERENCE;
 
 };  // namespace flutter
 

--- a/src/flutter/shell/platform/linux_embedded/flutter_elinux_view.h
+++ b/src/flutter/shell/platform/linux_embedded/flutter_elinux_view.h
@@ -318,7 +318,7 @@ class FlutterELinuxView : public WindowBindingHandlerDelegate {
   // Current view rotation (FlutterTransformation).
   FlutterTransformation view_rotation_transformation_ = {
       1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0};
-};
+} SWIFT_UNSAFE_REFERENCE;
 
 }  // namespace flutter
 

--- a/src/flutter/shell/platform/linux_embedded/public/flutter_elinux.h
+++ b/src/flutter/shell/platform/linux_embedded/public/flutter_elinux.h
@@ -216,8 +216,8 @@ FLUTTER_EXPORT FlutterDesktopViewRef FlutterDesktopPluginRegistrarGetView(
     FlutterDesktopPluginRegistrarRef registrar);
 
 // Returns the messenger associated with the engine.
-FLUTTER_EXPORT FlutterDesktopMessengerRef
-FlutterDesktopEngineGetMessenger(FlutterDesktopEngineRef engine);
+FLUTTER_EXPORT FlutterDesktopMessengerRef FlutterDesktopEngineGetMessenger(
+    FlutterDesktopEngineRef engine) SWIFT_RETURNS_UNRETAINED;
 
 // Returns the texture registrar associated with the engine.
 FLUTTER_EXPORT FlutterDesktopTextureRegistrarRef


### PR DESCRIPTION
This patch allows the importing of C++ engine APIs into Swift, using the Swift C++ bridging layer.

This fix is useful for [FlutterSwift](https://github.com/PADL/FlutterSwift), and shouldn't be intrusive to non-Swift use cases. I appreciate that this patch lack general utility and I am prepared to maintain a fork if required, but hope you can see the value in merging it.