### PR TITLE
Fix the scaling factor issue

### DIFF
--- a/src/flutter/shell/platform/linux_embedded/window/elinux_window.h
+++ b/src/flutter/shell/platform/linux_embedded/window/elinux_window.h
@@ -22,12 +22,12 @@ class ELinuxWindow {
 
   // Get current window width in physical pixels.
   uint32_t GetCurrentWidth() const {
-    return view_properties_.width * current_scale_;
+    return view_properties_.width;
   }
 
   // Get current window height in physical pixels.
   uint32_t GetCurrentHeight() const {
-    return view_properties_.height * current_scale_;
+    return view_properties_.height;
   }
 
   void SetRotation(FlutterDesktopViewRotation rotation) {


### PR DESCRIPTION
The issue occurs when using the **--force-scale-factor=\<value\>** startup parameter with the **gbm** backend.
![IMG_3624](https://github.com/user-attachments/assets/a9634d84-2b8d-4f0f-b036-1bf0981a9d33)
Before the modification, the **logical size** was incorrectly multiplied by the **scaling factor**, which caused the canvas to exceed the display.
![IMG_3626](https://github.com/user-attachments/assets/84652b40-48ae-4115-b97c-a170967afa44)
I am not familiar with **C++**, so I’m unsure whether this has led to other issues.

Commands:
```bash
sudo apt install libegl1-mesa-dev
cmake -DBUILD_ELINUX_SO=ON -DBACKEND_TYPE=DRM-GBM -DCMAKE_BUILD_TYPE=<Debug || Rlease> ..
mv libflutter_elinux_gbm.so .../flutter-elinux/flutter/bin/cache/artifacts/engine/elinux-<ARCH>-<debug || release>/libflutter_elinux_gbm.so
```